### PR TITLE
Adds support for using wrapping token as client token

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -99,7 +99,7 @@ impl<E: Endpoint> WrappedResponse<E> {
 
     /// Unwraps this response, returning the original response
     pub async fn unwrap(&self, client: &VaultClient) -> Result<E::Response, ClientError> {
-        wrapping::unwrap(client, self.info.token.as_str()).await
+        wrapping::unwrap(client, Some(self.info.token.as_str())).await
     }
 }
 

--- a/src/api/sys/requests.rs
+++ b/src/api/sys/requests.rs
@@ -119,7 +119,7 @@ pub struct ListAuthsRequest {}
 #[endpoint(path = "/sys/wrapping/unwrap", method = "POST", response = "Value")]
 #[builder(setter(into))]
 pub struct UnwrapRequest {
-    pub token: String,
+    pub token: Option<String>,
 }
 
 /// ## Wrapping Lookup

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -186,10 +186,10 @@ pub mod wrapping {
     /// See [UnwrapRequest]
     pub async fn unwrap<D: DeserializeOwned>(
         client: &VaultClient,
-        token: &str,
+        token: Option<&str>,
     ) -> Result<D, ClientError> {
         let endpoint = UnwrapRequest {
-            token: token.to_string(),
+            token: token.map(|v| v.to_string()),
         };
         let res = api::exec_with_result(client, endpoint).await?;
         serde_json::value::from_value(res).map_err(|e| ClientError::JsonParseError {


### PR DESCRIPTION
in order to unwrap said token without authenticating first.

From the `sys/wrapping/unwrap` api docs (https://www.vaultproject.io/api-docs/system/wrapping-unwrap#wrapping-unwrap):
> This endpoint can be used by using a wrapping token as the client token in the API call, in which case the token parameter is not required [...]. Do not use the wrapping token in both locations; this will cause the wrapping token to be revoked but the value to be unable to be looked up, as it will basically be a double-use of the token!

I have tested that it works. Should I add a test case to the cargo tests?