### PR TITLE
Fixes bug in generic login for clients

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,7 +54,8 @@ impl VaultClient {
         method: &impl LoginMethod,
     ) -> Result<(), ClientError> {
         let info = method.login(self, mount).await?;
-        self.settings.token = info.client_token;
+        self.settings.token = info.client_token.clone();
+        self.middle.token = info.client_token;
         Ok(())
     }
 


### PR DESCRIPTION
Apologies if I am fixing code that you did not intend to release yet; I am writing an application using this library and noticed the client login method does not take effect (requests to Vault are denied).