### PR TITLE
Upgrades cargo dependencies to latest versions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,11 +18,11 @@ jobs:
   audit:
     name: Security audit
     runs-on: ubuntu-latest
-    continue-on-error: true # Don't fail PRs due to potentially out-of-band fixes
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Run security audit
       uses: actions-rs/audit-check@v1
+      continue-on-error: true # Don't fail PRs due to potentially out-of-band fixes
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,6 +18,7 @@ jobs:
   audit:
     name: Security audit
     runs-on: ubuntu-latest
+    continue-on-error: true # Don't fail PRs due to potentially out-of-band fixes
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,22 +18,22 @@ members = [
 
 [dependencies]
 async-trait = "0.1.51"
-bytes = "1.0.1"
+bytes = "1.1.0"
 derive_builder = "0.10.2"
-http = "0.2.4"
-reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
-rustify = "0.5.0"
-rustify_derive = "0.5.0"
-serde = { version = "1.0.127", features = ["derive"] }
-serde_json = "1.0.66"
-thiserror = "1.0.26"
+http = "0.2.5"
+reqwest = { version = "0.11.6", default-features = false, features = ["rustls-tls"] }
+rustify = "0.5.2"
+rustify_derive = "0.5.2"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+thiserror = "1.0.30"
 url = "2.2.2"
-tracing = {version = "0.1.27", features = ["log"] }
+tracing = { version = "0.1.29", features = ["log"] }
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-tracing-subscriber = {version = "0.2.17", default-features = false, features = ["env-filter", "fmt"]}
-tracing-test = "0.1"
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["env-filter", "fmt"] }
+tracing-test = "0.1.0"
 test-env-log = { version = "0.2.7", features = ["trace"] }
 env_logger = "0.9.0"
-dockertest-server = { version = "0.1.3", features = ["hashi", "database"] }
+dockertest-server = { version = "0.1.4", features = ["hashi", "database"] }


### PR DESCRIPTION
Upgrading tracing-subscriber v0.2.17 -> v0.3.1
Upgrading tracing-test v0.1 -> v0.1.0
Upgrading serde v1.0.127 -> v1.0.130
Upgrading dockertest-server v0.1.3 -> v0.1.4
Upgrading serde_json v1.0.66 -> v1.0.68
Upgrading reqwest v0.11.4 -> v0.11.6
Upgrading http v0.2.4 -> v0.2.5
Upgrading bytes v1.0.1 -> v1.1.0
Upgrading thiserror v1.0.26 -> v1.0.30
Upgrading rustify_derive v0.5.0 -> v0.5.2
Upgrading tracing v0.1.27 -> v0.1.29
Upgrading rustify v0.5.0 -> v0.5.2