### PR TITLE
make version optional, fixes #24

### DIFF
--- a/src/api/kv2/requests.rs
+++ b/src/api/kv2/requests.rs
@@ -64,10 +64,9 @@ pub struct ReadSecretRequest {
     pub mount: String,
     #[endpoint(skip)]
     pub path: String,
-    #[endpoint(skip)]
+    #[builder(default = "None")]
     #[endpoint(query)]
-    #[builder(default = "0")]
-    pub version: u64,
+    pub version: Option<u64>,
 }
 
 /// ## Create/Update Secret

--- a/src/kv2.rs
+++ b/src/kv2.rs
@@ -153,7 +153,7 @@ pub async fn read_version<D: DeserializeOwned>(
     let endpoint = ReadSecretRequest::builder()
         .mount(mount)
         .path(path)
-        .version(version)
+        .version(Some(version))
         .build()
         .unwrap();
     let res = api::exec_with_result(client, endpoint).await?;


### PR DESCRIPTION
this will fix #24 

the UrlQueryParseError when using kv2::read(),
by optionally sending the version param instead of using default
value of 0