### PR TITLE
feat!: add support for cas option for kv2 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ kv2::set(
     "secret",
     "mysecret",
     &secret,
+    None,
 ).await;
 
 let secret: MySecret = kv2::read(&client, "secret", "mysecret").await.unwrap();

--- a/src/api/kv2/requests.rs
+++ b/src/api/kv2/requests.rs
@@ -90,6 +90,14 @@ pub struct SetSecretRequest {
     #[endpoint(skip)]
     pub path: String,
     pub data: Value,
+    #[builder(default)]
+    pub options: Option<SetSecretRequestOptions>,
+}
+
+#[derive(Builder, Clone, Debug, serde::Serialize)]
+#[builder(setter(into))]
+pub struct SetSecretRequestOptions {
+    pub cas: u32,
 }
 
 /// ## Delete Latest Version of Secret

--- a/src/kv2.rs
+++ b/src/kv2.rs
@@ -6,7 +6,8 @@ use crate::{
                 DeleteLatestSecretVersionRequest, DeleteSecretMetadataRequest,
                 DeleteSecretVersionsRequest, DestroySecretVersionsRequest, ListSecretsRequest,
                 ReadSecretMetadataRequest, ReadSecretRequest, SetSecretMetadataRequest,
-                SetSecretMetadataRequestBuilder, SetSecretRequest, UndeleteSecretVersionsRequest,
+                SetSecretMetadataRequestBuilder, SetSecretRequest, SetSecretRequestOptions,
+                UndeleteSecretVersionsRequest,
             },
             responses::{ReadSecretMetadataResponse, SecretVersionMetadata},
         },
@@ -169,6 +170,7 @@ pub async fn set<T: Serialize>(
     mount: &str,
     path: &str,
     data: &T,
+    options: Option<SetSecretRequestOptions>,
 ) -> Result<SecretVersionMetadata, ClientError> {
     let data_value = data
         .serialize(serde_json::value::Serializer)
@@ -177,6 +179,7 @@ pub async fn set<T: Serialize>(
         .mount(mount)
         .path(path)
         .data(data_value)
+        .options(options)
         .build()
         .unwrap();
     api::exec_with_result(client, endpoint).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@
 //!     "secret",
 //!     "mysecret",
 //!     &secret,
+//!     None,
 //! ).await;
 //!
 //! let secret: MySecret = kv2::read(&client, "secret", "mysecret").await.unwrap();

--- a/tests/kv2.rs
+++ b/tests/kv2.rs
@@ -6,7 +6,7 @@ mod common;
 use common::{VaultServer, VaultServerHelper};
 use serde::{Deserialize, Serialize};
 use test_log::test;
-use vaultrs::api::kv2::requests::SetSecretMetadataRequest;
+use vaultrs::api::kv2::requests::{SetSecretMetadataRequest, SetSecretRequestOptions};
 use vaultrs::client::Client;
 use vaultrs::error::ClientError;
 use vaultrs::kv2;
@@ -25,6 +25,7 @@ fn test() {
         test_read_metadata(&client, &endpoint).await;
         test_read_version(&client, &endpoint).await;
         test_set(&client, &endpoint).await;
+        test_set_with_compare_and_swap(&client, &endpoint).await;
         test_set_metadata(&client, &endpoint).await;
 
         // Test delete
@@ -104,8 +105,36 @@ async fn test_read_version(client: &impl Client, endpoint: &SecretEndpoint) {
 }
 
 async fn test_set(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::set(client, endpoint.path.as_str(), "test", &endpoint.secret).await;
+    let res = kv2::set(
+        client,
+        endpoint.path.as_str(),
+        "test",
+        &endpoint.secret,
+        None,
+    )
+    .await;
     assert!(res.is_ok());
+}
+
+async fn test_set_with_compare_and_swap(client: &impl Client, endpoint: &SecretEndpoint) {
+    let res = kv2::set(
+        client,
+        endpoint.path.as_str(),
+        "test-compare-and-swap",
+        &endpoint.secret,
+        Some(SetSecretRequestOptions { cas: 0 }),
+    )
+    .await;
+    assert!(res.is_ok());
+    let res = kv2::set(
+        client,
+        endpoint.path.as_str(),
+        "test-compare-and-swap",
+        &endpoint.secret,
+        Some(SetSecretRequestOptions { cas: 0 }),
+    )
+    .await;
+    assert!(res.is_err());
 }
 
 async fn test_set_metadata(client: &impl Client, endpoint: &SecretEndpoint) {
@@ -177,6 +206,7 @@ async fn create(client: &impl Client, endpoint: &SecretEndpoint) -> Result<(), C
         endpoint.path.as_str(),
         endpoint.name.as_str(),
         &endpoint.secret,
+        None,
     )
     .await?;
     Ok(())


### PR DESCRIPTION
This pull request adds support for vaults compare-and-swap feature. It contains breaking changes as the `kv2::set` signature is expanded with an additional `Option<SetSecretRequestOptions>` argument.

closes https://github.com/jmgilman/vaultrs/issues/33