### PR TITLE
fix: add missing format macro arg

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -186,7 +186,10 @@ impl VaultClientSettingsBuilder {
 
     fn default_address(&self) -> Result<Url, String> {
         let address = if let Ok(address) = env::var("VAULT_ADDR") {
-            info!("Using vault address from $VAULT_ADDR: {address}");
+            info!(
+                "Using vault address from $VAULT_ADDR: {address}",
+                address = address
+            );
             address
         } else {
             info!("Using default vault address http://127.0.0.1:8200");


### PR DESCRIPTION
@jmgilman I'm unable to build master (and 0.6.2) locally due to missing format-macro arg. 

```
error: there is no argument named `address`
   --> src/client.rs:189:58
    |
189 |             info!("Using vault address from $VAULT_ADDR: {address}");
```

I wonder how it builds on the CI ? :thinking: 

I forgot to mention (and git-add this) this in #36
