### PR TITLE
Allow to choose between rustls and native-tls TLS implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,18 @@ members = [
     "vaultrs-login",
 ]
 
+[features]
+default = [ "rustls" ]
+rustls = [ "reqwest/rustls-tls", "rustify/rustls-tls" ]
+native-tls = [ "reqwest/default-tls", "rustify/default" ]
+
 [dependencies]
 async-trait = "0.1.53"
 bytes = "1.1.0"
 derive_builder = "0.11.2"
 http = "0.2.7"
-reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
-rustify = { version = "0.5.3", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.10", default-features = false }
+rustify = { version = "0.5.3", default-features = false }
 rustify_derive = "0.5.2"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/README.md
+++ b/README.md
@@ -40,11 +40,26 @@ See something missing? [Open an issue](https://github.com/jmgilman/vaultrs/issue
 
 ## Installation
 
-Add `vaultrs` as a dependency to your cargo.toml:
+First, choose one of the two TLS implementations for `vaultrs`' connection to Vault:
+* `rustls` (default) to use [Rustls](https://github.com/rustls/rustls)
+* `native-tls` to use [rust-native-tls](https://github.com/sfackler/rust-native-tls),
+which builds on your platform-specific TLS implementation.
+
+Then, add `vaultrs` as a dependency to your cargo.toml:
+
+1. To use [Rustls](https://github.com/rustls/rustls), import as follows:
 
 ```toml
 [dependencies]
 vaultrs = "0.6.2"
+```
+
+2. To use [rust-native-tls](https://github.com/sfackler/rust-native-tls),
+which builds on your platform-specific TLS implementation, specify:
+
+```toml
+[dependencies]
+vaultrs = { version = "0.6.2", default-features = false, features = [ "native-tls" ] }
 ```
 
 ## Usage


### PR DESCRIPTION
First, many thanks for your great library! As you know, `reqwest` allows to choose from two TLS implementations (`rustls` and `native-tls`); however, for some reason (why?), `vaultrs` is fixed to using `rustls`: https://github.com/jmgilman/vaultrs/blob/a4c20bba8afb5e63174472683859719470686d04/Cargo.toml#L24-L25

This PR allows to choose via a feature between `rustls` and `native-tls` to avoid having two crypto stacks in the same binary. In my example (a project already depending on `native-tls` due to other libraries), this saved ~900kB in the (stripped) release binary.

For backwards compatibility, the PR makes sure that `rustls` is still chosen as the default TLS implementation. In a version 0.7, this could probably be simplified.