### PR TITLE
feat: add support for transit secrets engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { version = "0.1.34", features = ["log"] }
 
 [dev-dependencies]
 base64 = "0.13"
+data-encoding = "2.3.2"
 tokio-test = "0.4.2"
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["env-filter", "fmt"] }
 tracing-test = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following features are currently supported:
   * [KV v2](https://www.vaultproject.io/docs/secrets/kv/kv-v2)
   * [PKI](https://www.vaultproject.io/docs/secrets/pki)
   * [SSH](https://www.vaultproject.io/docs/secrets/ssh)
+  * [Transit](https://www.vaultproject.io/api-docs/secret/transit)
 * Sys
   * [Health](https://www.vaultproject.io/api-docs/system/health)
   * [Policies](https://www.vaultproject.io/api-docs/system/policy)
@@ -132,6 +133,28 @@ let cert = cert::generate(
     Some(GenerateCertificateRequest::builder().common_name("test.com")),
 ).await.unwrap();
 println!("{}", cert.certificate) // "{PEM encoded certificate}"
+```
+
+### Transit
+
+The library supports most operations for the
+[Transit](https://www.vaultproject.io/api-docs/secret/transit) secrets engine,
+other than importing keys or `batch_input` parameters.
+
+```rust
+use vaultrs::api::transit::requests::CreateKeyRequest;
+use vaultrs::api::transit::KeyType;
+
+// Create an encryption key using the /transit backend
+key::create(
+    &client,
+    "transit",
+    "my-transit-key",
+    Some(CreateKeyRequest::builder()
+       .derive(true)
+       .key_type(KeyType::Aes256Gcm96)
+       .auto_rotate_period("30d")),
+).await.unwrap();
 ```
 
 ### Wrapping

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,6 +5,7 @@ pub mod pki;
 pub mod ssh;
 pub mod sys;
 pub mod token;
+pub mod transit;
 
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/src/api/transit.rs
+++ b/src/api/transit.rs
@@ -1,0 +1,86 @@
+pub mod requests;
+pub mod responses;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum KeyType {
+    /// AES-128 wrapped with GCM using a 96-bit nonce size AEAD (symmetric,
+    /// supports derivation and convergent encryption)
+    Aes128Gcm96,
+    /// AES-256 wrapped with GCM using a 96-bit nonce size AEAD (symmetric,
+    /// supports derivation and convergent encryption, default)
+    Aes256Gcm96,
+    /// ChaCha20-Poly1305 AEAD (symmetric, supports derivation and convergent
+    /// encryption)
+    Chacha20Poly1305,
+    /// ED25519 (asymmetric, supports derivation). When using derivation, a sign
+    /// operation with the same context will derive the same key and signature;
+    /// this is a signing analogue to convergent_encryption.
+    Ed25519,
+    /// ECDSA using the P-256 elliptic curve (asymmetric)
+    EcdsaP256,
+    /// ECDSA using the P-384 elliptic curve (asymmetric)
+    EcdsaP384,
+    /// ECDSA using the P-521 elliptic curve (asymmetric)
+    EcdsaP521,
+    /// RSA with bit size of 2048 (asymmetric)
+    Rsa2048,
+    /// RSA with bit size of 3072 (asymmetric)
+    Rsa3072,
+    /// RSA with bit size of 4096 (asymmetric)
+    Rsa4096,
+}
+
+impl Default for KeyType {
+    fn default() -> Self {
+        Self::Aes256Gcm96
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OutputFormat {
+    Base64,
+    Hex,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Base64
+    }
+}
+
+/// Note: In FIPS 140-2 mode, the following algorithms are not certified and
+/// thus should not be used: sha3-224, sha3-256, sha3-384, and sha3-512.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HashAlgorithm {
+    Sha2_224,
+    Sha2_256,
+    Sha2_384,
+    Sha2_512,
+    Sha3_224,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SignatureAlgorithm {
+    Pss,
+    Pkcs1v15,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MarshalingAlgorithm {
+    /// The default, used by OpenSSL and X.509
+    Asn1,
+    /// The version used by JWS (and thus for JWTs). Selecting this will also
+    /// change the output encoding to URL-safe Base64 encoding instead of
+    /// standard Base64-encoding.
+    Jws,
+}

--- a/src/api/transit/requests.rs
+++ b/src/api/transit/requests.rs
@@ -1,0 +1,790 @@
+use super::responses::{
+    BackupKeyResponse, DecryptDataResponse, EncryptDataResponse, ExportKeyResponse,
+    GenerateDataKeyResponse, GenerateHmacResponse, GenerateRandomBytesResponse, HashDataResponse,
+    ListKeysResponse, ReadKeyResponse, ReadTransitCacheConfigurationResponse, RewrapDataResponse,
+    SignDataResponse, VerifySignedDataResponse,
+};
+use super::{HashAlgorithm, KeyType, MarshalingAlgorithm, OutputFormat, SignatureAlgorithm};
+use rustify_derive::Endpoint;
+use serde::Serialize;
+use std::fmt::Debug;
+
+/// ## Create Key
+/// This endpoint creates a new named encryption key of the specified type. The
+/// values set here cannot be changed after key creation.
+///
+/// * Path: {self.mount}/keys/{self.name}
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#create-key
+#[derive(Builder, Debug, Default, Endpoint, Serialize)]
+#[endpoint(
+    path = "{self.mount}/keys/{self.name}",
+    method = "POST",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct CreateKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the name of the encryption key to create.
+    #[endpoint(skip)]
+    pub name: String,
+    /// If enabled, the key will support convergent encryption, where the same
+    /// plaintext creates the same ciphertext. This requires derived to be set
+    /// to true. When enabled, each encryption(/decryption/rewrap/datakey)
+    /// operation will derive a nonce value rather than randomly generate it.
+    pub convergent_encryption: Option<bool>,
+    /// Specifies if key derivation is to be used. If enabled, all
+    /// encrypt/decrypt requests to this named key must provide a context which
+    /// is used for key derivation.
+    pub derive: Option<bool>,
+    /// Enables keys to be exportable. This allows for all the valid keys in the
+    /// key ring to be exported. Once set, this cannot be disabled.
+    pub exportable: Option<bool>,
+    /// If set, enables taking backup of named key in the plaintext format. Once
+    /// set, this cannot be disabled.
+    pub allow_plaintext_backup: Option<bool>,
+    /// Specifies the type of key to create.
+    #[serde(rename = "type")]
+    pub key_type: Option<KeyType>,
+    /// The period at which this key should be rotated automatically. Setting
+    /// this to "0" (the default) will disable automatic key rotation. This
+    /// value cannot be shorter than one hour.
+    pub auto_rotate_period: Option<String>,
+}
+
+/// ## Read Key
+/// This endpoint returns information about a named encryption key. The keys
+/// object shows the creation time of each key version; the values are not the
+/// keys themselves. Depending on the type of key, different information may be
+/// returned, e.g. an asymmetric key will return its public key in a standard
+/// format for the type.
+///
+/// * Path: {self.mount}/keys/{self.name}
+/// * Method: GET
+/// * Response: ReadKeyResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#read-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/keys/{self.name}",
+    response = "ReadKeyResponse",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct ReadKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+}
+
+/// ## List Keys
+/// This endpoint returns a list of keys. Only the key names are returned (not
+/// the actual keys themselves).
+///
+/// * Path: {self.mount}/keys
+/// * Method: LIST
+/// * Response: ListKeysResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#list-keys
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/keys",
+    response = "ListKeysResponse",
+    method = "LIST",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct ListKeysRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+}
+
+/// ## Update Key Configuration
+/// This endpoint allows tuning configuration values for a given key. (These
+/// values are returned during a read operation on the named key.)
+///
+/// * Path: {self.mount}/keys/{self.name}/config
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#update-key-configuration
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/keys/{self.name}/config",
+    method = "POST",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct UpdateKeyConfigurationRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the minimum version of ciphertext allowed to be decrypted.
+    /// Adjusting this as part of a key rotation policy can prevent old copies
+    /// of ciphertext from being decrypted, should they fall into the wrong
+    /// hands. For signatures, this value controls the minimum version of
+    /// signature that can be verified against. For HMACs, this controls the
+    /// minimum version of a key allowed to be used as the key for verification.
+    pub min_decryption_version: Option<u64>,
+    /// Specifies the minimum version of the key that can be used to encrypt
+    /// plaintext, sign payloads, or generate HMACs. Must be 0 (which will use
+    /// the latest version) or a value greater or equal to
+    /// min_decryption_version.
+    pub min_encryption_version: Option<u64>,
+    /// Specifies if the key is allowed to be deleted.
+    pub deletion_allowed: Option<bool>,
+    /// Enables keys to be exportable. This allows for all the valid keys in the
+    /// key ring to be exported. Once set, this cannot be disabled.
+    pub exportable: Option<bool>,
+    /// If set, enables taking backup of named key in the plaintext format. Once
+    /// set, this cannot be disabled.
+    pub allow_plaintext_backup: Option<bool>,
+    /// The period at which this key should be rotated automatically. Setting
+    /// this to "0" will disable automatic key rotation. This value cannot be
+    /// shorter than one hour. When no value is provided, the period remains
+    /// unchanged.
+    pub auto_rotate_period: Option<String>,
+}
+
+/// ## Delete Key
+/// This endpoint deletes a named encryption key. It will no longer be possible
+/// to decrypt any data encrypted with the named key. Because this is a
+/// potentially catastrophic operation, the deletion_allowed tunable must be set
+/// in the key's `/config` endpoint.
+///
+/// * Path: {self.mount}/keys/{self.name}
+/// * Method: DELETE
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#delete-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/keys/{self.name}",
+    method = "DELETE",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct DeleteKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+}
+
+/// ## Rotate Key
+/// This endpoint rotates the version of the named key. After rotation, new
+/// plaintext requests will be encrypted with the new version of the key. To
+/// upgrade ciphertext to be encrypted with the latest version of the key, use
+/// the rewrap endpoint. This is only supported with keys that support
+/// encryption and decryption operations.
+///
+/// * Path: {self.mount}/keys/{self.name}/rotate
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#rotate-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/keys/{self.name}/rotate",
+    method = "POST",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct RotateKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+}
+
+/// ## Export Key
+/// This endpoint returns the named key. The keys object shows the value of the
+/// key for each version. If version is specified, the specific version will be
+/// returned. If latest is provided as the version, the current key will be
+/// provided. Depending on the type of key, different information may be
+/// returned. The key must be exportable to support this operation and the
+/// version must still be valid.
+///
+/// * Path: {self.mount}/export/{self.key_type}/{self.name}(/{self.version})
+/// * Method: GET
+/// * Response: ExportKeyResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#export-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/export/{self.key_type}/{self.name}{self.version}",
+    response = "ExportKeyResponse",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct ExportKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub key_type: ExportKeyType,
+    #[endpoint(skip)]
+    pub name: String,
+    #[endpoint(skip)]
+    pub version: ExportVersion,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ExportKeyType {
+    EncryptionKey,
+    SigningKey,
+    HmacKey,
+}
+
+impl Default for ExportKeyType {
+    fn default() -> Self {
+        ExportKeyType::EncryptionKey
+    }
+}
+
+impl std::fmt::Display for ExportKeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EncryptionKey => write!(f, "encryption-key"),
+            Self::SigningKey => write!(f, "signing-key"),
+            Self::HmacKey => write!(f, "hmac-key"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ExportVersion {
+    All,
+    Latest,
+    Version(u64),
+}
+
+impl Default for ExportVersion {
+    fn default() -> Self {
+        ExportVersion::Latest
+    }
+}
+
+impl std::fmt::Display for ExportVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => Ok(()),
+            Self::Latest => write!(f, "/latest"),
+            Self::Version(n) => write!(f, "/{}", n),
+        }
+    }
+}
+
+/// ## Encrypt Data
+/// This endpoint encrypts the provided plaintext using the named key. This path
+/// supports the create and update policy capabilities as follows: if the user
+/// has the create capability for this endpoint in their policies, and the key
+/// does not exist, it will be upserted with default values (whether the key
+/// requires derivation depends on whether the context parameter is empty or
+/// not). If the user only has update capability and the key does not exist, an
+/// error will be returned.
+///
+/// * Path: {self.mount}/encrypt/{self.name}
+/// * Method: POST
+/// * Response: EncryptDataResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#encrypt-data
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/encrypt/{self.name}",
+    method = "POST",
+    response = "EncryptDataResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct EncryptDataRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the name of the encryption key to encrypt against.
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies base64 encoded plaintext to be encoded.
+    /// NOTE: All plaintext data must be base64-encoded. The reason for this
+    /// requirement is that Vault does not require that the plaintext is "text".
+    /// It could be a binary file such as a PDF or image. The easiest safe
+    /// transport mechanism for this data as part of a JSON payload is to
+    /// base64-encode it.
+    pub plaintext: String,
+    /// Specifies the base64 encoded context for key derivation. This is
+    /// required if key derivation is enabled for this key.
+    pub context: Option<String>,
+    /// Specifies the version of the key to use for encryption. If not set, uses
+    /// the latest version. Must be greater than or equal to the key's
+    /// min_encryption_version, if set.
+    pub key_version: Option<u64>,
+    /// Specifies the base64 encoded nonce value. This must be provided if
+    /// convergent encryption is enabled for this key and the key was generated
+    /// with Vault 0.6.1. Not required for keys created in 0.6.2+. The value
+    /// must be exactly 96 bits (12 bytes) long and the user must ensure that
+    /// for any given context (and thus, any given encryption key) this nonce
+    /// value is never reused.
+    pub nonce: Option<String>,
+    /// This parameter is required when encryption key is expected to be
+    /// created. When performing an upsert operation, the type of key to create.
+    pub key_type: Option<KeyType>,
+    /// This parameter will only be used when a key is expected to be created.
+    /// Whether to support convergent encryption. This is only supported when
+    /// using a key with key derivation enabled and will require all requests to
+    /// carry both a context and 96-bit (12-byte) nonce. The given nonce will be
+    /// used in place of a randomly generated nonce. As a result, when the same
+    /// context and nonce are supplied, the same ciphertext is generated. It is
+    /// very important when using this mode that you ensure that all nonces are
+    /// unique for a given context. Failing to do so will severely impact the
+    /// ciphertext's security.
+    pub convergent_encryption: Option<String>,
+}
+
+/// ## Decrypt Data
+/// This endpoint decrypts the provided ciphertext using the named key.
+///
+/// * Path: {self.mount}/decrypt/{self.name}
+/// * Method: POST
+/// * Response: DecryptDataResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#decrypt-data
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/decrypt/{self.name}",
+    method = "POST",
+    response = "DecryptDataResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct DecryptDataRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the name of the encryption key to decrypt against.
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the ciphertext to decrypt.
+    pub ciphertext: String,
+    /// Specifies the base64 encoded context for key derivation. This is
+    /// required if key derivation is enabled.
+    pub context: Option<String>,
+    /// Specifies a base64 encoded nonce value used during encryption. Must be
+    /// provided if convergent encryption is enabled for this key and the key
+    /// was generated with Vault 0.6.1. Not required for keys created in 0.6.2+.
+    pub nonce: Option<String>,
+}
+
+/// ## Rewrap Data
+/// This endpoint rewraps the provided ciphertext using the latest version of
+/// the named key. Because this never returns plaintext, it is possible to
+/// delegate this functionality to untrusted users or scripts.
+///
+/// * Path: {self.mount}/rewrap/{self.name}
+/// * Method: POST
+/// * Response: RewrapDataResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#rewrap-data
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/rewrap/{self.name}",
+    method = "POST",
+    response = "RewrapDataResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct RewrapDataRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the name of the encryption key to re-encrypt against.
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the ciphertext to re-encrypt.
+    pub ciphertext: String,
+    /// Specifies the base64 encoded context for key derivation. This is
+    /// required if key derivation is enabled.
+    pub context: Option<String>,
+    /// Specifies the version of the key to use for the operation. If not set,
+    /// uses the latest version. Must be greater than or equal to the key's
+    /// min_encryption_version, if set.
+    pub key_version: Option<u64>,
+    /// Specifies a base64 encoded nonce value used during encryption. Must be
+    /// provided if convergent encryption is enabled for this key and the key
+    /// was generated with Vault 0.6.1. Not required for keys created in 0.6.2+.
+    pub nonce: Option<String>,
+}
+
+/// ## Generate Data Key
+/// This endpoint generates a new high-entropy key and the value encrypted with
+/// the named key. Optionally return the plaintext of the key as well. Whether
+/// plaintext is returned depends on the path; as a result, you can use Vault
+/// ACL policies to control whether a user is allowed to retrieve the plaintext
+/// value of a key. This is useful if you want an untrusted user or operation to
+/// generate keys that are then made available to trusted users.
+///
+/// * Path: {self.mount}/datakey/{self.key_type}/{self.name}
+/// * Method: POST
+/// * Response: GenerateDataKeyResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#generate-data-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/datakey/{self.key_type}/{self.name}",
+    method = "POST",
+    response = "GenerateDataKeyResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GenerateDataKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the type of key to generate. If plaintext, the plaintext key
+    /// will be returned along with the ciphertext. If wrapped, only the
+    /// ciphertext value will be returned.
+    #[endpoint(skip)]
+    pub key_type: DataKeyType,
+    /// Specifies the name of the encryption key to use to encrypt the datakey.
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the key derivation context, provided as a base64-encoded
+    /// string. This must be provided if derivation is enabled.
+    pub context: Option<String>,
+    /// Specifies a nonce value, provided as base64 encoded. Must be provided if
+    /// convergent encryption is enabled for this key and the key was generated
+    /// with Vault 0.6.1. Not required for keys created in 0.6.2+. The value
+    /// must be exactly 96 bits (12 bytes) long and the user must ensure that
+    /// for any given context (and thus, any given encryption key) this nonce
+    /// value is never reused.
+    pub nonce: Option<String>,
+    /// Specifies the number of bits in the desired key. Can be 128, 256, or
+    /// 512. Default is 256 bits.
+    pub bits: Option<u16>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum DataKeyType {
+    Plaintext,
+    Wrapped,
+}
+
+impl Default for DataKeyType {
+    fn default() -> Self {
+        DataKeyType::Wrapped
+    }
+}
+
+impl std::fmt::Display for DataKeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plaintext => write!(f, "plaintext"),
+            Self::Wrapped => write!(f, "wrapped"),
+        }
+    }
+}
+
+/// ## Generate Random Bytes
+/// This endpoint returns high-quality random bytes of the specified length.
+///
+/// * Path: {self.mount}/random(/{self.source})(/{self.bytes})
+/// * Method: POST
+/// * Response: GenerateRandomBytesResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#generate-random-bytes
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/random",
+    method = "POST",
+    response = "GenerateRandomBytesResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GenerateRandomBytesRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the number of bytes to return. Default is 32.
+    pub bytes: Option<u32>,
+    /// Specifies the output encoding.
+    pub format: OutputFormat,
+    /// Specifies the source of the requested bytes.
+    pub source: RandomBytesSource,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RandomBytesSource {
+    /// Sources bytes from the platform's entropy source.
+    Platform,
+    /// Sources from entropy augmentation (enterprise only).
+    Seal,
+    /// Mixes bytes from all available sources.
+    All,
+}
+
+impl Default for RandomBytesSource {
+    fn default() -> Self {
+        RandomBytesSource::Platform
+    }
+}
+
+/// ## Hash Data
+/// This endpoint returns the cryptographic hash of given data using the
+/// specified algorithm.
+///
+/// * Path: {self.mount}/hash(/{self.algorithm)
+/// * Method: POST
+/// * Response: HashDataResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#hash-data
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/hash",
+    method = "POST",
+    response = "HashDataResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct HashDataRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the hash algorithm to use.
+    pub algorithm: Option<HashAlgorithm>,
+    /// Specifies the base64 encoded input data.
+    pub input: String,
+    /// Specifies the output encoding.
+    pub format: Option<OutputFormat>,
+}
+
+/// ## Generate HMAC
+/// This endpoint returns the digest of given data using the specified hash
+/// algorithm and the named key. The key can be of any type supported by
+/// transit; the raw key will be marshaled into bytes to be used for the HMAC
+/// function. If the key is of a type that supports rotation, the latest
+/// (current) version will be used.
+///
+/// * Path: {self.mount}/hmac/{self.name}(/{self.algorithm)
+/// * Method: POST
+/// * Response: GenerateHmacResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#generate-hmac
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/hmac/{self.name}",
+    method = "POST",
+    response = "GenerateHmacResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GenerateHmacRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the version of the key to use for the operation. If not set,
+    /// uses the latest version. Must be greater than or equal to the key's
+    /// min_encryption_version, if set.
+    pub key_version: Option<u64>,
+    /// Specifies the hash algorithm to use.
+    pub algorithm: Option<HashAlgorithm>,
+    /// Specifies the base64 encoded input data.
+    pub input: String,
+}
+
+/// ## Sign Data
+/// This endpoint returns the cryptographic signature of the given data using
+/// the named key and the specified hash algorithm. The key must be of a type
+/// that supports signing.
+///
+/// * Path: {self.mount}/sign/{self.name}(/{self.hash_algorithm)
+/// * Method: POST
+/// * Response: SignDataResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#sign-data
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/sign/{self.name}",
+    method = "POST",
+    response = "SignDataResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct SignDataRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the version of the key to use for the operation. If not set,
+    /// uses the latest version. Must be greater than or equal to the key's
+    /// min_encryption_version, if set.
+    pub key_version: Option<u64>,
+    /// Specifies the hash algorithm to use.
+    pub hash_algorithm: Option<HashAlgorithm>,
+    /// Specifies the base64 encoded input data.
+    pub input: String,
+    /// Base64 encoded context for key derivation. Required if key derivation is
+    /// enabled; currently only available with ed25519 keys.
+    pub context: Option<String>,
+    /// Set to true when the input is already hashed. If the key type is
+    /// rsa-2048, rsa-3072 or rsa-4096, then the algorithm used to hash the
+    /// input should be indicated by the hash_algorithm parameter. Just as the
+    /// value to sign should be the base64-encoded representation of the exact
+    /// binary data you want signed, when set, input is expected to be
+    /// base64-encoded binary hashed data, not hex-formatted.
+    pub prehashed: Option<bool>,
+    /// When using a RSA key, specifies the RSA signature algorithm to use for
+    /// signing.
+    pub signature_algorithm: Option<SignatureAlgorithm>,
+    /// Specifies the way in which the signature should be marshaled. This
+    /// currently only applies to ECDSA keys.
+    pub marshaling_algorithm: Option<MarshalingAlgorithm>,
+}
+
+/// ## Verify Signed Data
+/// This endpoint returns whether the provided signature is valid for the given
+/// data.
+///
+/// * Path: {self.mount}/verify/{self.name}(/{self.hash_algorithm)
+/// * Method: POST
+/// * Response: VerifySignedDataResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#verify-signed-data
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/verify/{self.name}",
+    method = "POST",
+    response = "VerifySignedDataResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct VerifySignedDataRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+    /// Specifies the hash algorithm to use.
+    pub hash_algorithm: Option<HashAlgorithm>,
+    /// Specifies the base64 encoded input data.
+    pub input: String,
+    /// Specifies the signature output from the /transit/sign function. Either
+    /// this must be supplied or hmac must be supplied.
+    pub signature: Option<String>,
+    /// Specifies the signature output from the /transit/hmac function. Either
+    /// this must be supplied or signature must be supplied.
+    pub hmac: Option<String>,
+    /// Base64 encoded context for key derivation. Required if key derivation is
+    /// enabled; currently only available with ed25519 keys.
+    pub context: Option<String>,
+    /// Set to true when the input is already hashed. If the key type is
+    /// rsa-2048, rsa-3072 or rsa-4096, then the algorithm used to hash the
+    /// input should be indicated by the hash_algorithm parameter.
+    pub prehashed: Option<bool>,
+    /// When using a RSA key, specifies the RSA signature algorithm to use for
+    /// signature verification.
+    pub signature_algorithm: Option<SignatureAlgorithm>,
+    /// Specifies the way in which the signature was originally marshaled. This
+    /// currently only applies to ECDSA keys.
+    pub marshaling_algorithm: Option<MarshalingAlgorithm>,
+}
+
+/// ## Backup Key
+/// This endpoint returns a plaintext backup of a named key. The backup contains
+/// all the configuration data and keys of all the versions along with the HMAC
+/// key. The response from this endpoint can be used with the /restore endpoint
+/// to restore the key.
+///
+/// * Path: {self.mount}/backup/{self.name}
+/// * Method: GET
+/// * Response: BackupKeyResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#backup-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/backup/{self.name}",
+    response = "BackupKeyResponse",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct BackupKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+}
+
+/// ## Restore Key
+/// This endpoint restores the backup as a named key. This will restore the key
+/// configurations and all the versions of the named key along with HMAC keys.
+/// The input to this endpoint should be the output of /backup endpoint.
+///
+/// * Path: {self.mount}/restore(/{self.name})
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#restore-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(path = "{self.mount}/restore", method = "POST", builder = "true")]
+#[builder(setter(into, strip_option), default)]
+pub struct RestoreKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Backed up key data to be restored. This should be the output from the
+    /// /backup endpoint.
+    pub backup: String,
+    /// If set, this will be the name of the restored key.
+    pub name: Option<String>,
+    /// If set, force the restore to proceed even if a key by this name already
+    /// exists.
+    pub force: Option<bool>,
+}
+
+/// ## Trim Key
+/// This endpoint trims older key versions setting a minimum version for the
+/// keyring. Once trimmed, previous versions of the key cannot be recovered.
+///
+/// * Path: {self.mount}/keys/{self.name}/trim
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#trim-key
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/keys/{self.name}/trim",
+    method = "POST",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct TrimKeyRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub name: String,
+    /// The minimum available version for the key ring. All versions before this
+    /// version will be permanently deleted. This value can at most be equal to
+    /// the lesser of min_decryption_version and min_encryption_version. This is
+    /// not allowed to be set when either min_encryption_version or
+    /// min_decryption_version is set to zero.
+    pub min_available_version: u64,
+}
+
+/// ## Configure Cache
+/// This endpoint is used to configure the transit engine's cache. Note that
+/// configuration changes will not be applied until the transit plugin is
+/// reloaded which can be achieved using the /sys/plugins/reload/backend
+/// endpoint.
+///
+/// * Path: {self.mount}/transit/cache-config
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#configure-cache
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(path = "{self.mount}/cache-config", method = "POST", builder = "true")]
+#[builder(setter(into, strip_option), default)]
+pub struct ConfigureCacheRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    /// Specifies the size in terms of number of entries. A size of 0 means
+    /// unlimited. A Least Recently Used (LRU) caching strategy is used for a
+    /// non-zero cache size. Must be 0 (default) or a value greater or equal to
+    /// 10 (minimum cache size).
+    pub size: Option<u64>,
+}
+
+/// ## Read Transit Cache Configuration
+/// This endpoint retrieves configurations for the transit engine's cache.
+///
+/// * Path: {self.mount}/transit/cache-config
+/// * Method: GET
+/// * Response: ReadTransitCacheConfigurationResponse
+/// * Reference: https://www.vaultproject.io/api-docs/secret/transit#read-transit-cache-configuration
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/cache-config",
+    response = "ReadTransitCacheConfigurationResponse",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct ReadTransitCacheConfigurationRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+}

--- a/src/api/transit/responses.rs
+++ b/src/api/transit/responses.rs
@@ -1,0 +1,117 @@
+use super::KeyType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Response from executing
+/// [ReadKeyRequest][crate::api::transit::requests::ReadKeyRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReadKeyResponse {
+    #[serde(rename = "type")]
+    pub key_type: KeyType,
+    pub deletion_allowed: bool,
+    pub derived: bool,
+    pub exportable: bool,
+    pub allow_plaintext_backup: bool,
+    pub keys: HashMap<String, u64>,
+    pub min_decryption_version: u64,
+    pub min_encryption_version: u64,
+    pub name: String,
+    pub supports_encryption: bool,
+    pub supports_decryption: bool,
+    pub supports_derivation: bool,
+    pub supports_signing: bool,
+    pub imported: Option<bool>,
+}
+
+/// Response from executing
+/// [ListKeysRequest][crate::api::transit::requests::ListKeysRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ListKeysResponse {
+    pub keys: Vec<String>,
+}
+
+/// Response from executing
+/// [ExportKeyRequest][crate::api::transit::requests::ExportKeyRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExportKeyResponse {
+    pub name: String,
+    pub keys: HashMap<String, String>,
+}
+
+/// Response from executing
+/// [EncryptDataRequest][crate::api::transit::requests::EncryptDataRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EncryptDataResponse {
+    pub ciphertext: String,
+}
+
+/// Response from executing
+/// [DecryptDataRequest][crate::api::transit::requests::DecryptDataRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DecryptDataResponse {
+    pub plaintext: String,
+}
+
+/// Response from executing
+/// [RewrapDataRequest][crate::api::transit::requests::RewrapDataRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RewrapDataResponse {
+    pub ciphertext: String,
+}
+
+/// Response from executing
+/// [GenerateDataKeyRequest][crate::api::transit::requests::GenerateDataKeyRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenerateDataKeyResponse {
+    pub plaintext: Option<String>,
+    pub ciphertext: String,
+}
+
+/// Response from executing
+/// [RandomBytesRequest][crate::api::transit::requests::RandomBytesRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenerateRandomBytesResponse {
+    pub random_bytes: String,
+}
+
+/// Response from executing
+/// [HashDataRequest][crate::api::transit::requests::HashDataRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HashDataResponse {
+    pub sum: String,
+}
+
+/// Response from executing
+/// [GenerateHmacRequest][crate::api::transit::requests::GenerateHmacRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenerateHmacResponse {
+    pub hmac: String,
+}
+
+/// Response from executing
+/// [SignDataRequest][crate::api::transit::requests::SignDataRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SignDataResponse {
+    pub signature: String,
+}
+
+/// Response from executing
+/// [VerifySignedDataRequest][crate::api::transit::requests::VerifySignedDataRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VerifySignedDataResponse {
+    pub valid: bool,
+}
+
+/// Response from executing
+/// [BackupKeyRequest][crate::api::transit::requests::BackupKeyRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupKeyResponse {
+    pub backup: String,
+}
+
+/// Response from executing
+/// [ReadTransitCacheConfigurationRequest][crate::api::transit::requests::ReadTransitCacheConfigurationRequest]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReadTransitCacheConfigurationResponse {
+    pub size: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //!   * [KV v2](https://www.vaultproject.io/docs/secrets/kv/kv-v2)
 //!   * [PKI](https://www.vaultproject.io/docs/secrets/pki)
 //!   * [SSH](https://www.vaultproject.io/docs/secrets/ssh)
+//!   * [Transit](https://www.vaultproject.io/api-docs/secret/transit)
 //! * Sys
 //!   * [Health](https://www.vaultproject.io/api-docs/system/health)
 //!   * [Policies](https://www.vaultproject.io/api-docs/system/policy)
@@ -205,3 +206,4 @@ pub mod pki;
 pub mod ssh;
 pub mod sys;
 pub mod token;
+pub mod transit;

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -1,0 +1,453 @@
+pub mod key {
+    use crate::api::transit::{
+        requests::{
+            BackupKeyRequest, CreateKeyRequest, CreateKeyRequestBuilder, DeleteKeyRequest,
+            ExportKeyRequest, ExportKeyType, ExportVersion, ListKeysRequest, ReadKeyRequest,
+            RestoreKeyRequest, RestoreKeyRequestBuilder, RotateKeyRequest, TrimKeyRequest,
+            UpdateKeyConfigurationRequest, UpdateKeyConfigurationRequestBuilder,
+        },
+        responses::{BackupKeyResponse, ExportKeyResponse, ListKeysResponse, ReadKeyResponse},
+    };
+    use crate::{api, client::Client, error::ClientError};
+
+    /// Create a new encryption key.
+    ///
+    /// See [CreateKeyRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn create(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        opts: Option<&mut CreateKeyRequestBuilder>,
+    ) -> Result<(), ClientError> {
+        let mut builder = CreateKeyRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    /// Read encryption key information.
+    ///
+    /// See [ReadKeyRequest]
+    #[instrument(skip(client), err)]
+    pub async fn read(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+    ) -> Result<ReadKeyResponse, ClientError> {
+        let endpoint = ReadKeyRequest::builder()
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// List key names.
+    ///
+    /// See [ListKeysRequest]
+    #[instrument(skip(client), err)]
+    pub async fn list(client: &impl Client, mount: &str) -> Result<ListKeysResponse, ClientError> {
+        let endpoint = ListKeysRequest::builder().mount(mount).build().unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Update a key's configuration.
+    ///
+    /// See [UpdateKeyConfigurationRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn update(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        opts: Option<&mut UpdateKeyConfigurationRequestBuilder>,
+    ) -> Result<(), ClientError> {
+        let mut builder = UpdateKeyConfigurationRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    /// Delete a named encryption key.
+    ///
+    /// See [DeleteKeyRequest]
+    #[instrument(skip(client), err)]
+    pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
+        let endpoint = DeleteKeyRequest::builder()
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    /// Rotate the version of a named key.
+    ///
+    /// See [RotateKeyRequest]
+    #[instrument(skip(client), err)]
+    pub async fn rotate(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
+        let endpoint = RotateKeyRequest::builder()
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    /// Export a named key.
+    ///
+    /// See [ExportKeyRequest]
+    #[instrument(skip(client), err)]
+    pub async fn export(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        key_type: ExportKeyType,
+        version: ExportVersion,
+    ) -> Result<ExportKeyResponse, ClientError> {
+        let endpoint = ExportKeyRequest::builder()
+            .mount(mount)
+            .name(name)
+            .key_type(key_type)
+            .version(version)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Return a plaintext backup of a named key.
+    ///
+    /// See [BackupKeyRequest]
+    #[instrument(skip(client), err)]
+    pub async fn backup(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+    ) -> Result<BackupKeyResponse, ClientError> {
+        let endpoint = BackupKeyRequest::builder()
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Restores the backup of a named key.
+    ///
+    /// See [RestoreKeyRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn restore(
+        client: &impl Client,
+        mount: &str,
+        backup: &str,
+        opts: Option<&mut RestoreKeyRequestBuilder>,
+    ) -> Result<(), ClientError> {
+        let mut builder = RestoreKeyRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .backup(backup)
+            .build()
+            .unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    /// Trim older key versions setting a minimum version for the keyring.
+    ///
+    /// See [TrimKeyRequest]
+    #[instrument(skip(client), err)]
+    pub async fn trim(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        min_available_version: u64,
+    ) -> Result<(), ClientError> {
+        let endpoint = TrimKeyRequest::builder()
+            .mount(mount)
+            .name(name)
+            .min_available_version(min_available_version)
+            .build()
+            .unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+}
+
+pub mod data {
+    use crate::api::transit::{
+        requests::{
+            DecryptDataRequest, DecryptDataRequestBuilder, EncryptDataRequest,
+            EncryptDataRequestBuilder, RewrapDataRequest, RewrapDataRequestBuilder,
+            SignDataRequest, SignDataRequestBuilder, VerifySignedDataRequest,
+            VerifySignedDataRequestBuilder,
+        },
+        responses::{
+            DecryptDataResponse, EncryptDataResponse, RewrapDataResponse, SignDataResponse,
+            VerifySignedDataResponse,
+        },
+    };
+    use crate::{api, client::Client, error::ClientError};
+
+    /// Encrypt base64-encoded plaintext data using the named key.
+    ///
+    /// See [EncryptDataRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn encrypt(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        plaintext: &str,
+        opts: Option<&mut EncryptDataRequestBuilder>,
+    ) -> Result<EncryptDataResponse, ClientError> {
+        let mut builder = EncryptDataRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .plaintext(plaintext)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Decrypt the provided ciphertext using the named key.
+    ///
+    /// See [DecryptDataRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn decrypt(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        ciphertext: &str,
+        opts: Option<&mut DecryptDataRequestBuilder>,
+    ) -> Result<DecryptDataResponse, ClientError> {
+        let mut builder = DecryptDataRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .ciphertext(ciphertext)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Rewrap the provided ciphertext using the latest version of the named
+    /// key.
+    ///
+    /// See [RewrapDataRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn rewrap(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        ciphertext: &str,
+        opts: Option<&mut RewrapDataRequestBuilder>,
+    ) -> Result<RewrapDataResponse, ClientError> {
+        let mut builder = RewrapDataRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .ciphertext(ciphertext)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Return the cryptographic signature of the base64-encoded input data.
+    ///
+    /// See [SignDataRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn sign(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        input: &str,
+        opts: Option<&mut SignDataRequestBuilder>,
+    ) -> Result<SignDataResponse, ClientError> {
+        let mut builder = SignDataRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .input(input)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Return whether the provided signature is valid for the base64-encoded
+    /// input data.
+    ///
+    /// See [SignDataRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn verify(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        input: &str,
+        opts: Option<&mut VerifySignedDataRequestBuilder>,
+    ) -> Result<VerifySignedDataResponse, ClientError> {
+        let mut builder = VerifySignedDataRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .input(input)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+}
+
+pub mod generate {
+    use crate::api::transit::{
+        requests::{
+            DataKeyType, GenerateDataKeyRequest, GenerateDataKeyRequestBuilder,
+            GenerateHmacRequest, GenerateHmacRequestBuilder, GenerateRandomBytesRequest,
+            GenerateRandomBytesRequestBuilder, HashDataRequest, HashDataRequestBuilder,
+            RandomBytesSource,
+        },
+        responses::{
+            GenerateDataKeyResponse, GenerateHmacResponse, GenerateRandomBytesResponse,
+            HashDataResponse,
+        },
+        OutputFormat,
+    };
+    use crate::{api, client::Client, error::ClientError};
+
+    /// Generate a new high-entropy key and the value encrypted with the named
+    /// key.
+    ///
+    /// See [GenerateDataKeyRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn data_key(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        key_type: DataKeyType,
+        opts: Option<&mut GenerateDataKeyRequestBuilder>,
+    ) -> Result<GenerateDataKeyResponse, ClientError> {
+        let mut builder = GenerateDataKeyRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .key_type(key_type)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Generate random bytes.
+    ///
+    /// See [GenerateRandomBytesRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn random_bytes(
+        client: &impl Client,
+        mount: &str,
+        format: OutputFormat,
+        source: RandomBytesSource,
+        opts: Option<&mut GenerateRandomBytesRequestBuilder>,
+    ) -> Result<GenerateRandomBytesResponse, ClientError> {
+        let mut builder = GenerateRandomBytesRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .format(format)
+            .source(source)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Return the cryptographic hash of the base64-encoded input data.
+    ///
+    /// See [HashDataRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn hash(
+        client: &impl Client,
+        mount: &str,
+        input: &str,
+        opts: Option<&mut HashDataRequestBuilder>,
+    ) -> Result<HashDataResponse, ClientError> {
+        let mut builder = HashDataRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .input(input)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Return the digest of the base64-encoded input data.
+    ///
+    /// See [GenerateHmacRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn hmac(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        input: &str,
+        opts: Option<&mut GenerateHmacRequestBuilder>,
+    ) -> Result<GenerateHmacResponse, ClientError> {
+        let mut builder = GenerateHmacRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut builder)
+            .mount(mount)
+            .name(name)
+            .input(input)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+}
+
+pub mod cache {
+    use crate::api::transit::{
+        requests::{
+            ConfigureCacheRequest, ConfigureCacheRequestBuilder,
+            ReadTransitCacheConfigurationRequest,
+        },
+        responses::ReadTransitCacheConfigurationResponse,
+    };
+    use crate::{api, client::Client, error::ClientError};
+
+    /// Read the transit cache configuration.
+    ///
+    /// See [ReadTransitCacheConfigurationRequest]
+    #[instrument(skip(client), err)]
+    pub async fn read(
+        client: &impl Client,
+        mount: &str,
+    ) -> Result<ReadTransitCacheConfigurationResponse, ClientError> {
+        let endpoint = ReadTransitCacheConfigurationRequest::builder()
+            .mount(mount)
+            .build()
+            .unwrap();
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Configure the transit engine's cache.
+    ///
+    /// See [ConfigureCacheRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn configure(
+        client: &impl Client,
+        mount: &str,
+        opts: Option<&mut ConfigureCacheRequestBuilder>,
+    ) -> Result<(), ClientError> {
+        let mut builder = ConfigureCacheRequest::builder();
+        let endpoint = opts.unwrap_or(&mut builder).mount(mount).build().unwrap();
+        api::exec_with_empty(client, endpoint).await
+    }
+}

--- a/tests/transit.rs
+++ b/tests/transit.rs
@@ -1,0 +1,470 @@
+#[macro_use]
+extern crate tracing;
+
+mod common;
+
+use common::{VaultServer, VaultServerHelper};
+use data_encoding::HEXLOWER;
+use sha2::{Digest, Sha256};
+use test_log::test;
+use vaultrs::{client::VaultClient, error::ClientError};
+
+#[test]
+fn test() {
+    let test = common::new_test();
+    test.run(|instance| async move {
+        let server: VaultServer = instance.server();
+        let endpoint = TransitEndpoint::setup(&server).await.unwrap();
+
+        key::test_create(&endpoint).await;
+        key::test_read(&endpoint).await;
+        key::test_list(&endpoint).await;
+        key::test_rotate(&endpoint).await;
+        key::test_update(&endpoint).await;
+        key::test_delete(&endpoint).await;
+        key::test_export(&endpoint).await;
+        key::test_backup_and_restore(&endpoint).await;
+        key::test_trim(&endpoint).await;
+
+        data::test_encrypt_and_rewrap_and_decrypt(&endpoint).await;
+        data::test_sign_and_verify(&endpoint).await;
+
+        generate::test_data_key(&endpoint).await;
+        generate::test_random_bytes(&endpoint).await;
+        generate::test_hash(&endpoint).await;
+        generate::test_hmac(&endpoint).await;
+
+        cache::test_configure_and_read(&endpoint).await
+    });
+}
+
+mod key {
+    use super::TransitEndpoint;
+    use vaultrs::api::transit::requests::{
+        CreateKeyRequest, ExportKeyType, ExportVersion, RestoreKeyRequest,
+        UpdateKeyConfigurationRequest,
+    };
+    use vaultrs::api::transit::KeyType;
+    use vaultrs::transit::key;
+
+    pub async fn test_create(endpoint: &TransitEndpoint) {
+        let resp = key::create(&endpoint.client, &endpoint.path, &endpoint.keys.basic, None).await;
+        assert!(resp.is_ok());
+
+        let resp = key::create(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            Some(
+                CreateKeyRequest::builder()
+                    .derive(true)
+                    .exportable(true)
+                    .allow_plaintext_backup(true)
+                    .key_type(KeyType::Aes256Gcm96)
+                    .auto_rotate_period("30d"),
+            ),
+        )
+        .await;
+        assert!(resp.is_ok());
+
+        let resp = key::create(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.delete,
+            None,
+        )
+        .await;
+        assert!(resp.is_ok());
+
+        let resp = key::create(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.signing,
+            Some(
+                CreateKeyRequest::builder()
+                    .derive(true)
+                    .key_type(KeyType::Ed25519),
+            ),
+        )
+        .await;
+        assert!(resp.is_ok());
+    }
+
+    pub async fn test_read(endpoint: &TransitEndpoint) {
+        let resp = key::read(&endpoint.client, &endpoint.path, &endpoint.keys.basic)
+            .await
+            .unwrap();
+        assert_eq!(&resp.name, &endpoint.keys.basic);
+
+        let resp = key::read(&endpoint.client, &endpoint.path, &endpoint.keys.export)
+            .await
+            .unwrap();
+        assert!(&resp.exportable);
+
+        let resp = key::read(&endpoint.client, &endpoint.path, &endpoint.keys.delete)
+            .await
+            .unwrap();
+        // requires config update first
+        assert!(!&resp.deletion_allowed);
+    }
+
+    pub async fn test_list(endpoint: &TransitEndpoint) {
+        let resp = key::list(&endpoint.client, &endpoint.path).await.unwrap();
+        assert!(&resp.keys.contains(&endpoint.keys.basic));
+        assert!(&resp.keys.contains(&endpoint.keys.export));
+    }
+
+    pub async fn test_rotate(endpoint: &TransitEndpoint) {
+        // key version 2
+        let resp = key::rotate(&endpoint.client, &endpoint.path, &endpoint.keys.export).await;
+        assert!(resp.is_ok());
+
+        // key version 3
+        let resp = key::rotate(&endpoint.client, &endpoint.path, &endpoint.keys.export).await;
+        assert!(resp.is_ok());
+    }
+
+    pub async fn test_update(endpoint: &TransitEndpoint) {
+        let resp = key::update(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            Some(
+                UpdateKeyConfigurationRequest::builder()
+                    .min_encryption_version(2u64)
+                    .min_decryption_version(2u64),
+            ),
+        )
+        .await;
+        assert!(resp.is_ok());
+
+        let resp = key::update(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.delete,
+            Some(UpdateKeyConfigurationRequest::builder().deletion_allowed(true)),
+        )
+        .await;
+        assert!(resp.is_ok());
+    }
+
+    pub async fn test_delete(endpoint: &TransitEndpoint) {
+        let resp = key::delete(&endpoint.client, &endpoint.path, &endpoint.keys.basic).await;
+        assert!(resp.is_err());
+
+        let resp = key::delete(&endpoint.client, &endpoint.path, &endpoint.keys.delete).await;
+        assert!(resp.is_ok());
+    }
+
+    pub async fn test_export(endpoint: &TransitEndpoint) {
+        let resp = key::export(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.basic,
+            ExportKeyType::EncryptionKey,
+            ExportVersion::All,
+        )
+        .await;
+        assert!(resp.is_err());
+
+        let latest = key::export(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            ExportKeyType::EncryptionKey,
+            ExportVersion::Latest,
+        )
+        .await
+        .unwrap();
+
+        let resp = key::export(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            ExportKeyType::EncryptionKey,
+            ExportVersion::Version(3),
+        )
+        .await
+        .unwrap();
+        assert_eq!(&resp.name, &endpoint.keys.export);
+        assert_eq!(resp.keys.len(), 1);
+        assert_eq!(&resp.keys, &latest.keys);
+
+        let resp = key::export(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            ExportKeyType::EncryptionKey,
+            ExportVersion::All,
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.keys.len(), 2);
+        assert!(resp.keys.contains_key("2"));
+        assert!(resp.keys.contains_key("3"));
+    }
+
+    pub async fn test_backup_and_restore(endpoint: &TransitEndpoint) {
+        let resp = key::backup(&endpoint.client, &endpoint.path, &endpoint.keys.basic).await;
+        assert!(resp.is_err());
+
+        let backup = key::backup(&endpoint.client, &endpoint.path, &endpoint.keys.export)
+            .await
+            .unwrap()
+            .backup;
+
+        let resp = key::restore(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            None,
+        )
+        .await;
+        assert!(resp.is_err());
+
+        let resp = key::restore(
+            &endpoint.client,
+            &endpoint.path,
+            &backup,
+            Some(RestoreKeyRequest::builder().force(true)),
+        )
+        .await;
+        assert!(resp.is_ok());
+    }
+
+    pub async fn test_trim(endpoint: &TransitEndpoint) {
+        let resp = key::trim(&endpoint.client, &endpoint.path, &endpoint.keys.export, 2).await;
+        assert!(resp.is_ok());
+    }
+}
+
+mod data {
+    use super::TransitEndpoint;
+    use vaultrs::api::transit::requests::{
+        DecryptDataRequest, EncryptDataRequest, RewrapDataRequest, SignDataRequest,
+        VerifySignedDataRequest,
+    };
+    use vaultrs::api::transit::SignatureAlgorithm;
+    use vaultrs::transit::{data, key};
+
+    pub async fn test_encrypt_and_rewrap_and_decrypt(endpoint: &TransitEndpoint) {
+        let encrypted = data::encrypt(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            &endpoint.data.secret,
+            Some(EncryptDataRequest::builder().context(&endpoint.data.context)),
+        )
+        .await
+        .unwrap();
+
+        // key version 4
+        let resp = key::rotate(&endpoint.client, &endpoint.path, &endpoint.keys.export).await;
+        assert!(resp.is_ok());
+
+        let rewrapped = data::rewrap(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            &encrypted.ciphertext,
+            Some(RewrapDataRequest::builder().context(&endpoint.data.context)),
+        )
+        .await
+        .unwrap();
+        assert!(encrypted.ciphertext != rewrapped.ciphertext);
+
+        let decrypted = data::decrypt(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            &encrypted.ciphertext,
+            Some(DecryptDataRequest::builder().context(&endpoint.data.context)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(&decrypted.plaintext, &endpoint.data.secret);
+
+        let decrypted = data::decrypt(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.export,
+            &rewrapped.ciphertext,
+            Some(DecryptDataRequest::builder().context(&endpoint.data.context)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(&decrypted.plaintext, &endpoint.data.secret);
+    }
+
+    pub async fn test_sign_and_verify(endpoint: &TransitEndpoint) {
+        let signed = data::sign(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.signing,
+            &endpoint.data.secret,
+            Some(
+                SignDataRequest::builder()
+                    .context(&endpoint.data.context)
+                    .signature_algorithm(SignatureAlgorithm::Pkcs1v15),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let verified = data::verify(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.signing,
+            &endpoint.data.secret,
+            Some(
+                VerifySignedDataRequest::builder()
+                    .context(&endpoint.data.context)
+                    .signature(&signed.signature)
+                    .signature_algorithm(SignatureAlgorithm::Pkcs1v15),
+            ),
+        )
+        .await
+        .unwrap();
+        assert!(verified.valid);
+    }
+}
+
+mod generate {
+    use super::TransitEndpoint;
+    use vaultrs::api::transit::requests::{
+        DataKeyType, GenerateDataKeyRequest, GenerateRandomBytesRequest, HashDataRequest,
+        RandomBytesSource,
+    };
+    use vaultrs::api::transit::{HashAlgorithm, OutputFormat};
+    use vaultrs::transit::generate;
+
+    pub async fn test_data_key(endpoint: &TransitEndpoint) {
+        let resp = generate::data_key(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.basic,
+            DataKeyType::Plaintext,
+            Some(GenerateDataKeyRequest::builder().bits(512u16)),
+        )
+        .await
+        .unwrap();
+        assert!(&resp.plaintext.is_some())
+    }
+
+    pub async fn test_random_bytes(endpoint: &TransitEndpoint) {
+        let resp = generate::random_bytes(
+            &endpoint.client,
+            &endpoint.path,
+            OutputFormat::Hex,
+            RandomBytesSource::Platform,
+            Some(GenerateRandomBytesRequest::builder().bytes(10u32)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.random_bytes.len(), 20)
+    }
+
+    pub async fn test_hash(endpoint: &TransitEndpoint) {
+        let resp = generate::hash(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.data.context,
+            Some(
+                HashDataRequest::builder()
+                    .algorithm(HashAlgorithm::Sha2_256)
+                    .format(OutputFormat::Hex),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.sum, endpoint.data.context_shasum_hex);
+    }
+
+    pub async fn test_hmac(endpoint: &TransitEndpoint) {
+        let resp = generate::hmac(
+            &endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.basic,
+            &endpoint.data.context,
+            None,
+        )
+        .await;
+        assert!(resp.is_ok());
+    }
+}
+
+mod cache {
+    use super::TransitEndpoint;
+    use vaultrs::api::transit::requests::ConfigureCacheRequest;
+    use vaultrs::transit::cache;
+
+    pub async fn test_configure_and_read(endpoint: &TransitEndpoint) {
+        let resp = cache::configure(
+            &endpoint.client,
+            &endpoint.path,
+            Some(ConfigureCacheRequest::builder().size(123u64)),
+        )
+        .await;
+        assert!(resp.is_ok());
+
+        let resp = cache::read(&endpoint.client, &endpoint.path).await.unwrap();
+        assert_eq!(resp.size, 123);
+    }
+}
+
+pub struct TestKeys {
+    pub basic: String,
+    pub export: String,
+    pub delete: String,
+    pub signing: String,
+}
+
+pub struct TestData {
+    pub context: String,
+    pub context_shasum_hex: String,
+    pub secret: String,
+}
+
+impl TestData {
+    fn new(context: &str, secret: &str) -> Self {
+        let mut context_sha = Sha256::new();
+        context_sha.update(context);
+
+        TestData {
+            context: base64::encode(context),
+            context_shasum_hex: HEXLOWER.encode(&context_sha.finalize()),
+            secret: base64::encode(secret),
+        }
+    }
+}
+
+pub struct TransitEndpoint {
+    pub client: VaultClient,
+    pub path: String,
+    pub keys: TestKeys,
+    pub data: TestData,
+}
+
+impl TransitEndpoint {
+    async fn setup(server: &VaultServer) -> Result<Self, ClientError> {
+        debug!("setting up transit secrets engine");
+
+        let endpoint = TransitEndpoint {
+            client: server.client(),
+            path: "transit-test".into(),
+            keys: TestKeys {
+                basic: "basic-key".into(),
+                export: "export-key".into(),
+                delete: "delete-key".into(),
+                signing: "signing-key".into(),
+            },
+            data: TestData::new("test-context", "super secret data"),
+        };
+
+        server
+            .mount_secret(&endpoint.client, &endpoint.path, "transit")
+            .await?;
+
+        Ok(endpoint)
+    }
+}


### PR DESCRIPTION
Resolves #5 

This implements most of the transit secrets engine API, minus importing external keys or `batch_input` parameters (but would be easy enough to add on top).