### PR TITLE
KV2: add support for custom metadata

### DIFF
--- a/src/api/kv2/requests.rs
+++ b/src/api/kv2/requests.rs
@@ -4,6 +4,7 @@ use super::responses::{
 };
 use rustify_derive::Endpoint;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 /// ## Configure the KV Engine
@@ -256,6 +257,7 @@ pub struct SetSecretMetadataRequest {
     pub max_versions: Option<u64>,
     pub cas_required: Option<bool>,
     pub delete_version_after: Option<String>,
+    pub custom_metadata: Option<HashMap<String, String>>,
 }
 
 /// ## Delete Metadata and All Versions

--- a/src/api/kv2/responses.rs
+++ b/src/api/kv2/responses.rs
@@ -26,6 +26,7 @@ pub struct ReadSecretResponse {
 pub struct SecretVersionMetadata {
     pub created_time: String,
     pub deletion_time: String,
+    pub custom_metadata: Option<HashMap<String, String>>,
     pub destroyed: bool,
     pub version: u64,
 }
@@ -48,6 +49,7 @@ pub struct ReadSecretMetadataResponse {
     pub max_versions: u64,
     pub oldest_version: u64,
     pub updated_time: String,
+    pub custom_metadata: Option<HashMap<String, String>>,
     pub versions: HashMap<String, SecretMetadata>,
 }
 


### PR DESCRIPTION
Hello, this adds support for the [`custom_metadata` map in KV2](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-metadata).