### PR TITLE
native tls vendored feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
 default = [ "rustls" ]
 rustls = [ "reqwest/rustls-tls", "rustify/rustls-tls" ]
 native-tls = [ "reqwest/default-tls", "rustify/default" ]
+native-tls-vendored = [ "reqwest/native-tls-vendored", "rustify/default" ]
 
 [dependencies]
 async-trait = "0.1.68"


### PR DESCRIPTION
small change to enable the use of `native-tls-vendored` feature in `reqwest`

was having `openssl` issues and this was the only way i could build: https://github.com/seanmonstar/reqwest/issues/377

