### PR TITLE
feat: AWS Secret Engine

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod aws;
 pub mod database;
 pub mod kv1;
 pub mod kv2;

--- a/src/api/aws.rs
+++ b/src/api/aws.rs
@@ -1,0 +1,2 @@
+pub mod requests;
+pub mod responses;

--- a/src/api/aws/requests.rs
+++ b/src/api/aws/requests.rs
@@ -1,0 +1,262 @@
+use rustify_derive::Endpoint;
+use std::fmt::Debug;
+
+use super::responses::{
+    GenerateCredentialsResponse, GetConfigurationResponse, ListRolesResponse, ReadLeaseResponse,
+    ReadRoleResponse, RotateRootCredentialsResponse,
+};
+
+/// ## Configure Root IAM Credentials
+///
+/// Configures the root IAM credentials to communicate with AWS.
+///
+/// * Path: {self.mount}/config/root
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#configure-root-iam-credentials
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(path = "{self.mount}/config/root", method = "POST", builder = "true")]
+#[builder(setter(into, strip_option), default)]
+pub struct SetConfigurationRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    pub max_retries: Option<i32>,
+    pub access_key: String,
+    pub secret_key: String,
+    pub region: Option<String>,
+    pub iam_endpoint: Option<String>,
+    pub sts_endpoint: Option<String>,
+    pub username_template: Option<String>,
+}
+
+/// ## Read Root Configuration
+///
+/// Read non-secure values that have been configured in the config/root endpoint
+///
+/// * Path: {self.mount}/config/root
+/// * Method: GET
+/// * Response: [GetConfigurationResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#read-root-configuration
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/config/root",
+    method = "GET",
+    builder = "true",
+    response = "GetConfigurationResponse"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GetConfigurationRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+}
+
+/// ## Rotate Root IAM Credentials
+///
+/// When you have configured Vault with static credentials, you can use this endpoint to have Vault rotate the access key it used.
+///
+/// * Path: {self.mount}/config/rotate-root
+/// * Method: GET
+/// * Response: [RotateRootCredentialsResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#rotate-root-iam-credentials
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/config/rotate-root",
+    method = "POST",
+    builder = "true",
+    response = "RotateRootCredentialsResponse"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct RotateRootCredentialsRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+}
+
+/// ## Configure Lease
+///
+/// Configures lease settings for the AWS secrets engine
+///
+/// * Path: {self.mount}/config/lease
+/// * Method: POST
+/// * Response: N.A.
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#configure-lease
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(path = "{self.mount}/config/lease", method = "POST", builder = "true")]
+#[builder(setter(into, strip_option), default)]
+pub struct ConfigureLeaseRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+
+    pub lease: String,
+    pub lease_max: String,
+}
+
+/// ## Read Lease
+///
+/// Returns the current lease settings for the AWS secrets engine
+///
+/// * Path: {self.mount}/config/lease
+/// * Method: GET
+/// * Response: [ReadLeaseResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#read-lease
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/config/lease",
+    method = "GET",
+    response = "ReadLeaseResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct ReadLeaseRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+}
+
+/// ## Create/Update Role
+///
+/// Creates or updates the role with the given name
+///
+/// * Path: {self.mount}/roles/{self.name}
+/// * Method: POST
+/// * Response: N.A.
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#create-update-role
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/roles/{self.name}",
+    method = "POST",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct CreateUpdateRoleRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+
+    pub name: String,
+    pub credential_type: String,
+    pub role_arns: Option<Vec<String>>,
+    pub policy_arns: Option<Vec<String>>,
+    pub policy_document: String,
+    pub iam_groups: Option<Vec<String>>,
+    pub iam_tags: Option<Vec<String>>,
+    pub default_sts_ttl: Option<u32>,
+    pub max_sts_ttl: Option<u32>,
+    pub user_path: Option<String>,
+    pub permissions_boundary_arn: Option<String>,
+
+    pub policy: Option<String>,
+    pub arn: Option<String>,
+}
+
+/// ## Read Role
+///
+/// Queries an existing role by the given name
+///
+/// * Path: {self.mount}/roles/{self.name}
+/// * Method: GET
+/// * Response: [ReadRoleResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#read-role
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/roles/{self.name}",
+    method = "GET",
+    response = "ReadRoleResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct ReadRoleRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+
+    pub name: String,
+}
+
+/// ## List Roles
+///
+///  lists all existing roles in the secrets engine
+///
+/// * Path: {self.mount}/roles
+/// * Method: LIST
+/// * Response: [ListRolesResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#list-roles
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/roles",
+    method = "LIST",
+    response = "ListRolesResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct ListRolesRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+}
+
+/// ## Delete Role
+///
+/// Deletes an existing role by the given name
+///
+/// * Path: {self.mount}/roles/{self.name}
+/// * Method: DELETE
+/// * Response: N.A.
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#delete-role
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/roles/{self.name}",
+    method = "DELETE",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct DeleteRoleRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    pub name: String,
+}
+
+/// ## Generate Credentials (/aws/creds)
+///
+/// Generates credentials based on the named role using /aws/creds endpoint
+///
+/// * Path: {self.mount}/creds/{self.name}
+/// * Method: GET
+/// * Response: [GenerateCredentialsResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#generate-credentials
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/creds/{self.name}",
+    method = "GET",
+    response = "GenerateCredentialsResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GenerateCredentialsRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    pub name: String,
+    pub role_arn: Option<String>,
+    pub role_session_name: Option<String>,
+    pub ttl: Option<String>,
+}
+
+/// ## Generate Credentials (/aws/sts)
+///
+/// Generates credentials based on the named role using /aws/sts endpoint
+///
+/// * Path: {self.mount}/sts/{self.name}
+/// * Method: POST
+/// * Response: [GenerateCredentialsResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/secret/aws#generate-credentials
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/sts/{self.name}",
+    method = "POST",
+    response = "GenerateCredentialsResponse",
+    builder = "true"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GenerateCredentialsStsRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    pub name: String,
+    pub role_arn: Option<String>,
+    pub role_session_name: Option<String>,
+    pub ttl: Option<String>,
+}

--- a/src/api/aws/responses.rs
+++ b/src/api/aws/responses.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from executing
+/// [GetConfigurationRequest][crate::api::aws::requests::GetConfigurationRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct GetConfigurationResponse {
+    pub access_key: String,
+    pub region: String,
+    pub iam_endpoint: String,
+    pub sts_endpoint: String,
+    pub max_retries: u32,
+}
+
+/// Response from executing
+/// [RotateRootCredentialsRequest][crate::api::aws::requests::RotateRootCredentialsRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct RotateRootCredentialsResponse {
+    pub access_key: String,
+}
+
+/// Response from executing
+/// [ReadLeaseRequest][crate::api::aws::requests::ReadLeaseRequest]
+
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ReadLeaseResponse {
+    pub lease: String,
+    pub lease_max: String,
+}
+
+/// Response from executing
+/// [ReadRoleRequest][crate::api::aws::requests::ReadRoleRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ReadRoleResponse {
+    pub policy_document: Option<String>,
+    pub policy_arns: Option<Vec<String>>,
+    pub credential_type: String,
+    pub role_arns: Option<Vec<String>>,
+    pub iam_groups: Option<Vec<String>>,
+}
+
+/// Response from executing
+/// [ListRolesRequest][crate::api::aws::requests::ListRolesRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ListRolesResponse {
+    pub keys: Vec<String>,
+}
+
+/// Response from executing
+/// [GenerateCredentialsRequest][crate::api::aws::requests::GenerateCredentialsRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct GenerateCredentialsResponse {
+    pub access_key: String,
+    pub secret_key: String,
+    pub security_token: Option<String>,
+    pub arn: String,
+}

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,0 +1,205 @@
+pub mod config {
+
+    use crate::{
+        api::{
+            self,
+            aws::{
+                requests::{
+                    ConfigureLeaseRequest, GetConfigurationRequest, ReadLeaseRequest,
+                    RotateRootCredentialsRequest, SetConfigurationRequest,
+                    SetConfigurationRequestBuilder,
+                },
+                responses::{
+                    GetConfigurationResponse, ReadLeaseResponse, RotateRootCredentialsResponse,
+                },
+            },
+        },
+        client::Client,
+        error::ClientError,
+    };
+
+    /// Configures the root IAM credentials to communicate with AWS.
+    ///
+    /// See [SetConfigurationRequest]
+    #[instrument(skip(client, opts), err)]
+    pub async fn set(
+        client: &impl Client,
+        mount: &str,
+        access_key: &str,
+        secret_key: &str,
+        opts: Option<&mut SetConfigurationRequestBuilder>,
+    ) -> Result<(), ClientError> {
+        let mut t = SetConfigurationRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut t)
+            .mount(mount)
+            .access_key(access_key)
+            .secret_key(secret_key)
+            .build()
+            .unwrap();
+
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    #[instrument(skip(client), err)]
+    pub async fn get(
+        client: &impl Client,
+        mount: &str,
+    ) -> Result<GetConfigurationResponse, ClientError> {
+        let e = GetConfigurationRequest::builder()
+            .mount(mount)
+            .build()
+            .unwrap();
+
+        api::exec_with_result(client, e).await
+    }
+
+    #[instrument(skip(client), err)]
+    pub async fn rotate(
+        client: &impl Client,
+        mount: &str,
+    ) -> Result<RotateRootCredentialsResponse, ClientError> {
+        let endpoint = RotateRootCredentialsRequest::builder()
+            .mount(mount)
+            .build()
+            .unwrap();
+
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Configures the root IAM credentials to communicate with AWS.
+    ///
+    /// See [SetConfigurationRequest]
+    #[instrument(skip(client), err)]
+    pub async fn set_lease(
+        client: &impl Client,
+        mount: &str,
+        lease: &str,
+        lease_max: &str,
+    ) -> Result<(), ClientError> {
+        let endpoint = ConfigureLeaseRequest::builder()
+            .mount(mount)
+            .lease(lease)
+            .lease_max(lease_max)
+            .build()
+            .unwrap();
+
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    #[instrument(skip(client), err)]
+    pub async fn read_lease(
+        client: &impl Client,
+        mount: &str,
+    ) -> Result<ReadLeaseResponse, ClientError> {
+        let endpoint = ReadLeaseRequest::builder().mount(mount).build().unwrap();
+
+        api::exec_with_result(client, endpoint).await
+    }
+}
+
+pub mod roles {
+
+    use crate::{
+        api::{
+            self,
+            aws::{
+                requests::{
+                    CreateUpdateRoleRequest, CreateUpdateRoleRequestBuilder, DeleteRoleRequest,
+                    GenerateCredentialsRequest, GenerateCredentialsRequestBuilder,
+                    GenerateCredentialsStsRequest, GenerateCredentialsStsRequestBuilder,
+                    ListRolesRequest, ReadRoleRequest,
+                },
+                responses::{GenerateCredentialsResponse, ListRolesResponse, ReadRoleResponse},
+            },
+        },
+        client::Client,
+        error::ClientError,
+    };
+
+    #[instrument(skip(client, opts), err)]
+    pub async fn create_update(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        credential_type: &str,
+        opts: Option<&mut CreateUpdateRoleRequestBuilder>,
+    ) -> Result<(), ClientError> {
+        let mut t = CreateUpdateRoleRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut t)
+            .mount(mount)
+            .name(name)
+            .credential_type(credential_type)
+            .build()
+            .unwrap();
+
+        api::exec_with_empty(client, endpoint).await
+    }
+
+    pub async fn read(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+    ) -> Result<ReadRoleResponse, ClientError> {
+        let e = ReadRoleRequest::builder()
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+
+        api::exec_with_result(client, e).await
+    }
+
+    pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
+        let e = DeleteRoleRequest::builder()
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+
+        api::exec_with_empty(client, e).await
+    }
+
+    pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
+        let e = ListRolesRequest::builder().mount(mount).build().unwrap();
+
+        api::exec_with_result(client, e).await
+    }
+
+    /// Generate credentials using /aws/creds endpoint
+    pub async fn credentials(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        opts: Option<&mut GenerateCredentialsRequestBuilder>,
+    ) -> Result<GenerateCredentialsResponse, ClientError> {
+        let mut t = GenerateCredentialsRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut t)
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+
+        api::exec_with_result(client, endpoint).await
+    }
+
+    /// Generate credentials using /aws/sts endpoint
+    pub async fn credentials_sts(
+        client: &impl Client,
+        mount: &str,
+        name: &str,
+        opts: Option<&mut GenerateCredentialsStsRequestBuilder>,
+    ) -> Result<GenerateCredentialsResponse, ClientError> {
+        let mut t = GenerateCredentialsStsRequest::builder();
+        let endpoint = opts
+            .unwrap_or(&mut t)
+            .mount(mount)
+            .name(name)
+            .build()
+            .unwrap();
+
+        api::exec_with_result(client, endpoint).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ extern crate tracing;
 
 pub mod api;
 pub mod auth;
+pub mod aws;
 pub mod client;
 pub mod database;
 pub mod error;

--- a/tests/aws.rs
+++ b/tests/aws.rs
@@ -9,14 +9,14 @@ use vaultrs::client::Client;
 use vaultrs::error::ClientError;
 
 #[test]
-fn test() {
+fn test_auth() {
     let test = common::new_aws_test();
 
     test.run(|instance| async move {
         let server: VaultServer = instance.server();
         let localstack: LocalStackServer = instance.server();
         let client = server.client();
-        let endpoint = setup(&server, &client).await.unwrap();
+        let endpoint = setup_auth_engine(&server, &client).await.unwrap();
 
         crate::config::client::test_set(&localstack, &client, &endpoint).await;
         crate::config::client::test_read(&client, &endpoint).await;
@@ -63,13 +63,45 @@ fn test() {
     });
 }
 
+#[test]
+fn test_secret_engine() {
+    let test = common::new_aws_test();
+
+    test.run(|instance| async move {
+        let server: VaultServer = instance.server();
+        let localstack: LocalStackServer = instance.server();
+        let client = server.client();
+        let endpoint = setup_secret_engine(&server, &client).await.unwrap();
+
+        crate::secretengine::config::test_set(&localstack, &client, &endpoint).await;
+        crate::secretengine::config::test_get(&client, &endpoint).await;
+        crate::secretengine::config::test_rotate(&client, &endpoint).await;
+        crate::secretengine::config::test_set_lease(&client, &endpoint).await;
+        crate::secretengine::config::test_read_lease(&client, &endpoint).await;
+
+        crate::secretengine::roles::test_create_update(&client, &endpoint).await;
+        crate::secretengine::roles::test_read(&client, &endpoint).await;
+        crate::secretengine::roles::test_list(&client, &endpoint).await;
+        crate::secretengine::roles::test_credentials(&client, &endpoint).await;
+        crate::secretengine::roles::test_credentials_sts(&client, &endpoint).await;
+        crate::secretengine::roles::test_delete(&client, &endpoint).await;
+    });
+}
+
 #[derive(Debug)]
 pub struct AwsAuthEndpoint {
     pub path: String,
     pub role_name: String,
 }
 
-async fn setup(server: &VaultServer, client: &impl Client) -> Result<AwsAuthEndpoint, ClientError> {
+pub struct AwsSecretEngineEndpoint {
+    pub path: String,
+}
+
+async fn setup_auth_engine(
+    server: &VaultServer,
+    client: &impl Client,
+) -> Result<AwsAuthEndpoint, ClientError> {
     debug!("setting up AWS auth engine");
 
     let path = "aws_test";
@@ -82,6 +114,21 @@ async fn setup(server: &VaultServer, client: &impl Client) -> Result<AwsAuthEndp
     Ok(AwsAuthEndpoint {
         path: path.to_string(),
         role_name: role_name.to_string(),
+    })
+}
+
+async fn setup_secret_engine(
+    server: &VaultServer,
+    client: &impl Client,
+) -> Result<AwsSecretEngineEndpoint, ClientError> {
+    debug!("setting up AWS secret engine");
+
+    let path = "aws_test";
+
+    server.mount_secret(client, path, "aws").await?;
+
+    Ok(AwsSecretEngineEndpoint {
+        path: path.to_string(),
     })
 }
 
@@ -483,5 +530,174 @@ mod role_tag_deny_list {
         )
         .await;
         assert!(res.is_ok())
+    }
+}
+
+pub mod secretengine {
+
+    pub mod config {
+        use dockertest_server::servers::cloud::localstack::LocalStackServer;
+        use vaultrs::{api::aws::requests::SetConfigurationRequest, aws};
+
+        use crate::{AwsSecretEngineEndpoint, Client};
+
+        pub async fn test_set(
+            localstack: &LocalStackServer,
+            client: &impl Client,
+            endpoint: &AwsSecretEngineEndpoint,
+        ) {
+            let res = aws::config::set(
+                client,
+                &endpoint.path,
+                "test",
+                "test",
+                Some(
+                    SetConfigurationRequest::builder()
+                        .max_retries(3)
+                        .region("eu-central-1")
+                        .sts_endpoint(localstack.internal_url())
+                        .iam_endpoint(localstack.internal_url()),
+                ),
+            )
+            .await;
+
+            assert!(res.is_ok())
+        }
+
+        pub async fn test_get(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::config::get(client, &endpoint.path).await;
+
+            assert!(res.is_ok());
+
+            let data = res.unwrap();
+            assert!(data.access_key == "test");
+            assert!(data.max_retries == 3);
+            assert!(data.region == "eu-central-1");
+        }
+
+        // Doesn't work with Localstack, probably because of limitation with IAM APIs implementation
+        // and Vault method of rotating keys
+        // let's keep the call at least to avoid obvious errors, but it will return 500 with Vault + Localstack
+        pub async fn test_rotate(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let _res = aws::config::rotate(client, &endpoint.path).await;
+
+            // assert!(res.is_ok());
+            // assert!(res.unwrap().access_key.starts_with("AKIA"));
+        }
+
+        pub async fn test_set_lease(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::config::set_lease(client, &endpoint.path, "1h", "6h").await;
+
+            assert!(res.is_ok());
+        }
+
+        pub async fn test_read_lease(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::config::read_lease(client, &endpoint.path).await;
+
+            assert!(res.is_ok());
+
+            let data = res.unwrap();
+
+            // response looks like "1h0m0s"
+            assert!(data.lease.starts_with("1h"));
+            assert!(data.lease_max.starts_with("6h"));
+        }
+    }
+
+    pub mod roles {
+        use vaultrs::{
+            api::aws::requests::{
+                CreateUpdateRoleRequest, GenerateCredentialsRequest, GenerateCredentialsStsRequest,
+            },
+            aws,
+        };
+
+        use crate::{AwsSecretEngineEndpoint, Client};
+
+        pub const TEST_ROLE: &str = "test_role";
+        pub const TEST_ARN: &str = "arn:aws:iam::123456789012:role/test_role";
+
+        pub async fn test_create_update(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::roles::create_update(
+                client,
+                &endpoint.path,
+                TEST_ROLE,
+                "assumed_role",
+                Some(CreateUpdateRoleRequest::builder().role_arns(vec![TEST_ARN.to_string()])),
+            )
+            .await;
+
+            assert!(res.is_ok())
+        }
+
+        pub async fn test_read(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::roles::read(client, &endpoint.path, TEST_ROLE).await;
+
+            assert!(res.is_ok());
+
+            let data = res.unwrap();
+            let roles = data.role_arns.unwrap();
+
+            assert!(data.credential_type == "assumed_role");
+            assert!(roles[0] == TEST_ARN);
+            assert!(roles.len() == 1);
+        }
+
+        pub async fn test_list(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::roles::list(client, &endpoint.path).await;
+
+            assert!(res.is_ok());
+
+            let data = res.unwrap();
+            assert!(data.keys[0] == TEST_ROLE);
+            assert!(data.keys.len() == 1);
+        }
+
+        pub async fn test_credentials(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::roles::credentials(
+                client,
+                &endpoint.path,
+                TEST_ROLE,
+                Some(GenerateCredentialsRequest::builder().ttl("3h")),
+            )
+            .await;
+
+            assert!(res.is_ok());
+
+            let data = res.unwrap();
+            assert!(data.access_key.starts_with("ASIA"));
+            assert!(data.secret_key.len() > 0);
+            assert!(data.security_token.unwrap().len() > 0);
+        }
+
+        pub async fn test_credentials_sts(
+            client: &impl Client,
+            endpoint: &AwsSecretEngineEndpoint,
+        ) {
+            let res = aws::roles::credentials_sts(
+                client,
+                &endpoint.path,
+                TEST_ROLE,
+                Some(GenerateCredentialsStsRequest::builder().ttl("3h")),
+            )
+            .await;
+
+            assert!(res.is_ok());
+
+            let data = res.unwrap();
+            assert!(data.access_key.starts_with("ASIA"));
+            assert!(data.secret_key.len() > 0);
+            assert!(data.security_token.unwrap().len() > 0);
+        }
+
+        pub async fn test_delete(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
+            let res = aws::roles::delete(client, &endpoint.path, TEST_ROLE).await;
+
+            assert!(res.is_ok());
+
+            // check deletion actually worked, list should be empty (Vault returns 404)
+            let res_after = aws::roles::list(client, &endpoint.path).await;
+            assert!(res_after.is_err());
+        }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -22,6 +22,7 @@ pub const PORT: u32 = 8300;
 pub const VERSION: &str = "1.10.3";
 pub const NGINX_PORT: u32 = 8888;
 pub const NGINX_VERSION: &str = "1.21";
+pub const LOCALSTACK_VERSION: &str = "2.0.2";
 
 #[async_trait]
 pub trait VaultServerHelper {
@@ -170,7 +171,7 @@ pub fn new_aws_test() -> Test {
                 .into_iter()
                 .collect::<HashMap<_, _>>(),
         )
-        .version("0.14.3".to_string())
+        .version(LOCALSTACK_VERSION.to_string())
         .build()
         .unwrap();
     test.register(localstack_config);


### PR DESCRIPTION
Adds support for [AWS Secret Engine](https://developer.hashicorp.com/vault/docs/secrets/aws) with tests and docs

I tried to re-use existing code pattern and modules and tests, feel free to comment if it does not match somehow so code can be kept clean

Implementation is being used by a https://github.com/novadiscovery/novops branch, it works fine so far :)