### PR TITLE
feat: bumps vaultrs version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.8.0] - 2023-06-29
+
+### Added
+
+- Support for reqwest middleware builder
+
 ## [0.7.0] - 2023-03-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vaultrs"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
 description = "An asynchronous Rust client library for the Hashicorp Vault API."
 license = "MIT"
@@ -27,7 +27,9 @@ bytes = "1.4.0"
 derive_builder = "0.12.0"
 http = "0.2.9"
 reqwest = { version = "0.11.15", default-features = false }
-rustify = { version = "0.5.3", default-features = false }
+reqwest-middleware = { version = "0.2.2", default-features = false }
+#rustify = { version = "0.5.4", default-features = false }
+rustify = { git = "https://github.com/ChorusOne/rustify", rev="ba3a1c68f503a0ecf92af37ee8f0198720786bab", default-features = false, features = ["reqwest", "reqwest-middleware"] }
 rustify_derive = "0.5.2"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"


### PR DESCRIPTION
* client middleware builder for VaultClient constructor
* after the related PR (https://github.com/jmgilman/rustify/pull/14) for dependency is merged, update the dependency for crates.io, create the PR in the upstream repo