### PR TITLE
add sys init endpoint

### DIFF
--- a/src/api/sys/requests.rs
+++ b/src/api/sys/requests.rs
@@ -1,6 +1,6 @@
 use super::responses::{
     AuthResponse, ListPoliciesResponse, MountResponse, ReadHealthResponse, ReadPolicyResponse,
-    UnsealResponse, WrappingLookupResponse,
+    StartInitializationResponse, UnsealResponse, WrappingLookupResponse,
 };
 use rustify_derive::Endpoint;
 use serde::Serialize;
@@ -159,6 +159,47 @@ pub struct WrappingLookupRequest {
 )]
 #[builder(setter(into), default)]
 pub struct ReadHealthRequest {}
+
+/// ## Start Initialization
+///
+/// This endpoint initializes a new Vault. The Vault must not have been previously initialized.
+/// The recovery options, as well as the stored shares option, are only available when using Auto Unseal.
+///
+/// * Path: /sys/init
+/// * Method: POST
+/// * Response: [StartInitializationResponse]
+/// * Reference: https://developer.hashicorp.com/vault/api-docs/system/init#start-initialization
+#[derive(Builder, Default, Endpoint)]
+#[endpoint(
+    path = "/sys/init",
+    method = "POST",
+    response = "StartInitializationResponse",
+    builder = "true"
+)]
+#[builder(setter(into), default)]
+pub struct StartInitializationRequest {
+    /// Specifies an array of PGP public keys used to encrypt the output unseal keys. Ordering is preserved.
+    /// The keys must be base64-encoded from their original binary representation. The size of this array must be the same as secret_shares.
+    pgp_keys: Option<Vec<String>>,
+    /// Specifies a PGP public key used to encrypt the initial root token. The key must be base64-encoded from its original binary representation.
+    root_token_pgp_key: Option<String>,
+    /// Specifies the number of shares to split the root key into.
+    secret_shares: u64,
+    /// Specifies the number of shares required to reconstruct the root key. This must be less than or equal secret_shares.
+    secret_threshold: u64,
+
+    /// Additionally, the following options are only supported using Auto Unseal:
+    /// Specifies the number of shares that should be encrypted by the HSM and stored for auto-unsealing. Currently must be the same as secret_shares.
+    stored_shares: Option<u64>,
+    /// Specifies the number of shares to split the recovery key into. This is only available when using Auto Unseal.
+    recovery_shares: Option<u64>,
+    /// Specifies the number of shares required to reconstruct the recovery key. This must be less than or equal to recovery_shares.
+    /// This is only available when using Auto Unseal.
+    recovery_threshold: Option<u64>,
+    /// Specifies an array of PGP public keys used to encrypt the output recovery keys. Ordering is preserved.
+    /// The keys must be base64-encoded from their original binary representation. The size of this array must be the same as recovery_shares. This is only available when using Auto Unseal.
+    recovery_pgp_keys: Option<Vec<String>>,
+}
 
 /// ## Seal
 /// This endpoint seals the Vault.

--- a/src/api/sys/responses.rs
+++ b/src/api/sys/responses.rs
@@ -82,9 +82,9 @@ pub struct ReadHealthResponse {
 /// [StartInitializationRequest][crate::api::sys::requests::StartInitializationRequest]
 #[derive(Deserialize, Debug, Serialize)]
 pub struct StartInitializationResponse {
-    keys: Vec<String>,
-    keys_base64: Vec<String>,
-    root_token: String,
+    pub keys: Vec<String>,
+    pub keys_base64: Vec<String>,
+    pub root_token: String,
 }
 
 /// Response from executing

--- a/src/api/sys/responses.rs
+++ b/src/api/sys/responses.rs
@@ -79,6 +79,15 @@ pub struct ReadHealthResponse {
 }
 
 /// Response from executing
+/// [StartInitializationRequest][crate::api::sys::requests::StartInitializationRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct StartInitializationResponse {
+    keys: Vec<String>,
+    keys_base64: Vec<String>,
+    root_token: String,
+}
+
+/// Response from executing
 /// [UnsealRequest][crate::api::sys::requests::UnsealRequest]
 #[derive(Deserialize, Debug, Serialize)]
 pub struct UnsealResponse {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -2,8 +2,11 @@ use crate::{
     api::{
         self,
         sys::{
-            requests::{ReadHealthRequest, SealRequest, UnsealRequest},
-            responses::{ReadHealthResponse, UnsealResponse},
+            requests::{
+                ReadHealthRequest, SealRequest, StartInitializationRequest,
+                StartInitializationRequestBuilder, UnsealRequest,
+            },
+            responses::{ReadHealthResponse, StartInitializationResponse, UnsealResponse},
         },
     },
     client::Client,
@@ -28,6 +31,26 @@ pub enum ServerStatus {
 #[instrument(skip(client), err)]
 pub async fn health(client: &impl Client) -> Result<ReadHealthResponse, ClientError> {
     let endpoint = ReadHealthRequest::builder().build().unwrap();
+    api::exec_with_no_result(client, endpoint).await
+}
+
+/// Initialize a new Vault. The Vault must not have been previously initialized.
+///
+/// See [StartInitializationRequest]
+#[instrument(skip(client, opts), err)]
+pub async fn start_initialization(
+    client: &impl Client,
+    secret_shares: u64,
+    secret_threshold: u64,
+    opts: Option<&mut StartInitializationRequestBuilder>,
+) -> Result<StartInitializationResponse, ClientError> {
+    let mut t = StartInitializationRequest::builder();
+    let endpoint = opts
+        .unwrap_or(&mut t)
+        .secret_shares(secret_shares)
+        .secret_threshold(secret_threshold)
+        .build()
+        .unwrap();
     api::exec_with_no_result(client, endpoint).await
 }
 

--- a/tests/sys.rs
+++ b/tests/sys.rs
@@ -188,9 +188,7 @@ pub fn new_prod_test() -> Test {
         ],
         "storage": [
             {
-                "file": {
-                    "path": "/vault/file"
-                }
+                "inmem": {}
             }
         ],
         "disable_mlock": true

--- a/tests/sys.rs
+++ b/tests/sys.rs
@@ -5,7 +5,8 @@ use test_log::test;
 use vaultrs::{
     api::{sys::requests::ListMountsRequest, ResponseWrapper},
     client::Client,
-    sys::{self},
+    error::ClientError,
+    sys,
 };
 
 #[test]
@@ -20,6 +21,9 @@ fn test() {
 
         // Test health
         test_health(&client).await;
+
+        // Test initialization
+        test_start_initialization(&client).await;
 
         // Test status
         test_status(&client).await;
@@ -62,6 +66,16 @@ async fn test_wrap(client: &impl Client) {
 async fn test_health(client: &impl Client) {
     let resp = sys::health(client).await;
     assert!(resp.is_ok());
+}
+
+async fn test_start_initialization(client: &impl Client) {
+    let resp = sys::start_initialization(client, 1, 1, None)
+        .await
+        .unwrap_err();
+    let ClientError::APIError { code, .. } = resp else {
+        panic!("must return an error because already initialized")
+    };
+    assert_eq!(code, 400);
 }
 
 async fn test_seal(client: &impl Client) {

--- a/tests/vault_prod_container.rs
+++ b/tests/vault_prod_container.rs
@@ -1,0 +1,115 @@
+// This file is copied from https://github.com/jmgilman/dockertest-server/blob/master/src/servers/hashi/vault.rs
+// because of the LOG_MSG condition is only applicable to vault dev server.
+
+use derive_builder::Builder;
+use dockertest::{waitfor, Source};
+use dockertest_server::{Config, ContainerConfig, Server};
+use std::collections::HashMap;
+
+const IMAGE: &str = "vault";
+const PORT: u32 = 8300;
+const LOG_MSG: &str = "Vault server started!";
+const SOURCE: Source = Source::DockerHub;
+
+/// Configuration for creating a Hashicorp Vault server.
+///
+/// A token with root permissions will automatically be generated using the
+/// `token` field. If it's omitted the token will automatically be generated.
+///
+/// By default the Vault server listens on port 8200 for HTTP requests. This
+/// is exposed on the container by default, but the exposed port can be
+/// controlled by setting the `port` field.
+///
+/// See the [Dockerhub](https://hub.docker.com/_/vault) page for more
+/// information on the arguments and environment variables that can be used to
+/// configure the server.
+#[derive(Clone, Default, Builder)]
+#[builder(default)]
+pub struct VaultServerConfig {
+    #[builder(default = "vec![String::from(\"server\")]")]
+    pub args: Vec<String>,
+    #[builder(default = "HashMap::new()")]
+    pub env: HashMap<String, String>,
+    #[builder(default = "dockertest_server::server::new_handle(IMAGE)")]
+    pub handle: String,
+    #[builder(default = "8200")]
+    pub port: u32,
+    #[builder(default = "15")]
+    pub timeout: u16,
+    #[builder(default = "String::from(\"latest\")")]
+    pub version: String,
+}
+
+impl VaultServerConfig {
+    pub fn builder() -> VaultServerConfigBuilder {
+        VaultServerConfigBuilder::default()
+    }
+}
+
+impl Config for VaultServerConfig {
+    fn into_composition(self) -> dockertest::Composition {
+        let ports = vec![(PORT, self.port)];
+
+        let timeout = self.timeout;
+        let wait = Box::new(waitfor::MessageWait {
+            message: LOG_MSG.into(),
+            source: waitfor::MessageSource::Stdout,
+            timeout,
+        });
+
+        ContainerConfig {
+            args: self.args,
+            env: self.env,
+            handle: self.handle,
+            name: IMAGE.into(),
+            source: SOURCE,
+            version: self.version,
+            ports: Some(ports),
+            wait: Some(wait),
+            bind_mounts: HashMap::new(),
+        }
+        .into()
+    }
+
+    fn handle(&self) -> &str {
+        self.handle.as_str()
+    }
+}
+
+/// A running instance of a Vault server.
+///
+/// The server URL which is accessible from the local host can be found in `local_address`.
+/// Other running containers which need access to this server should use the
+/// `address` field instead.
+pub struct VaultServer {
+    pub external_port: u32,
+    pub internal_port: u32,
+    pub ip: String,
+}
+
+impl VaultServer {
+    fn format_address(&self, host: &str, port: u32) -> String {
+        format!("{}:{}", host, port)
+    }
+
+    fn format_url(&self, host: &str, port: u32) -> String {
+        format!("http://{}", self.format_address(host, port))
+    }
+
+    /// The external HTTP address
+    pub fn external_url(&self) -> String {
+        self.format_url("localhost", self.external_port)
+    }
+}
+
+impl Server for VaultServer {
+    type Config = VaultServerConfig;
+
+    fn new(config: &Self::Config, container: &dockertest::RunningContainer) -> Self {
+        VaultServer {
+            external_port: config.port,
+            internal_port: PORT,
+            ip: container.ip().to_string(),
+        }
+    }
+}


### PR DESCRIPTION
This add the `/sys/init` endpoint, which is useful to automate production Vault initialization.