### PR TITLE
prevent leaking unseal key

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -66,7 +66,7 @@ pub async fn seal(client: &impl Client) -> Result<(), ClientError> {
 /// Unseals the Vault server.
 ///
 /// See [UnsealRequest]
-#[instrument(skip(client), err)]
+#[instrument(skip(client, key), err)]
 pub async fn unseal(
     client: &impl Client,
     key: Option<String>,


### PR DESCRIPTION
Currently the unseal key is logged when requesting `/sys/unseal` . This is problematic because even if the user  only  prints log to stdout, the unseal key could be written on the disk because of the swap mechanism. Besides, it's the users that configure their subscriber, so they could end up sending their unseal key to a remote log server without even noticing it. 


This PR prevents the unseal key from being logged. 

> Note: this might be worth checking out if other APIs don't also leak sensitive information.