### PR TITLE
Improve logging

### DIFF
--- a/src/auth/approle.rs
+++ b/src/auth/approle.rs
@@ -11,7 +11,6 @@ use crate::{
 // Fetch a token with policies in corresponding AppRole.
 //
 // See [LoginWithApproleRequest]
-#[instrument(skip(client, secret_id), err)]
 pub async fn login(
     client: &impl Client,
     mount: &str,
@@ -51,7 +50,6 @@ pub mod role {
     /// Lists all AppRoles.
     ///
     /// See [ListRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -60,7 +58,6 @@ pub mod role {
     /// Reads properties of an AppRole.
     ///
     /// See [ReadAppRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -77,7 +74,6 @@ pub mod role {
     /// Creates or updates an AppRole.
     ///
     /// See [SetAppRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -97,7 +93,6 @@ pub mod role {
     /// Deletes an existing AppRole.
     ///
     /// See [DeleteAppRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(
         client: &impl Client,
         mount: &str,
@@ -114,7 +109,6 @@ pub mod role {
     /// Reads the RoleID of an existing AppRole.
     ///
     /// See [ReadRoleIDRequest]
-    #[instrument(skip(client), err)]
     pub async fn read_id(
         client: &impl Client,
         mount: &str,
@@ -131,7 +125,6 @@ pub mod role {
     /// Updates the Role ID of an AppRole.
     ///
     /// See [UpdateRoleIDRequest]
-    #[instrument(skip(client), err)]
     pub async fn update_id(
         client: &impl Client,
         mount: &str,
@@ -165,7 +158,6 @@ pub mod role {
         /// Creates a custom secret ID.
         ///
         /// See [CreateCustomSecretIDRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn custom(
             client: &impl Client,
             mount: &str,
@@ -187,7 +179,6 @@ pub mod role {
         /// Deletes an AppRole secret ID.
         ///
         /// See [DeleteSecretIDRequest]
-        #[instrument(skip(client), err)]
         pub async fn delete(
             client: &impl Client,
             mount: &str,
@@ -206,7 +197,6 @@ pub mod role {
         /// Deletes an AppRole secret ID by accessor.
         ///
         /// See [DeleteSecretIDAccessorRequest]
-        #[instrument(skip(client), err)]
         pub async fn delete_accessor(
             client: &impl Client,
             mount: &str,
@@ -225,7 +215,6 @@ pub mod role {
         /// Generates and issues a new SecretID on an existing AppRole.
         ///
         /// See [GenerateNewSecretIDRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn generate(
             client: &impl Client,
             mount: &str,
@@ -245,7 +234,6 @@ pub mod role {
         /// Lists ApplRole secret IDs.
         ///
         /// See [ListSecretIDRequest]
-        #[instrument(skip(client), err)]
         pub async fn list(
             client: &impl Client,
             mount: &str,
@@ -262,7 +250,6 @@ pub mod role {
         /// Reads an AppleRole secret ID.
         ///
         /// See [ReadSecretIDRequest]
-        #[instrument(skip(client), err)]
         pub async fn read(
             client: &impl Client,
             mount: &str,
@@ -281,7 +268,6 @@ pub mod role {
         /// Reads an AppleRole secret ID by accessor.
         ///
         /// See [ReadSecretIDAccessorRequest]
-        #[instrument(skip(client), err)]
         pub async fn read_accessor(
             client: &impl Client,
             mount: &str,

--- a/src/auth/aws.rs
+++ b/src/auth/aws.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 // See [IamLoginRequest]
-#[instrument(skip(client, iam_request_headers, iam_request_body), err)]
 pub async fn iam_login(
     client: &impl Client,
     mount: &str,
@@ -35,7 +34,6 @@ pub async fn iam_login(
 }
 
 // See [Ec2LoginRequest]
-#[instrument(skip(client, pkcs7, nonce), err)]
 pub async fn ec2_login(
     client: &impl Client,
     mount: &str,
@@ -77,7 +75,6 @@ pub mod config {
         /// Configures the credentials required to perform API calls to AWS as well as custom endpoints to talk to AWS APIs.
         ///
         /// See [ConfigureClientRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn set(
             client: &impl Client,
             mount: &str,
@@ -91,7 +88,6 @@ pub mod config {
         /// Returns the previously configured AWS access credentials.
         ///
         /// See [ReadClientConfigurationResponse]
-        #[instrument(skip(client), err)]
         pub async fn read(
             client: &impl Client,
             mount: &str,
@@ -106,7 +102,6 @@ pub mod config {
         /// Deletes the previously configured AWS access credentials.
         ///
         /// See [DeleteClientConfigurationRequest]
-        #[instrument(skip(client), err)]
         pub async fn delete(client: &impl Client, mount: &str) -> Result<(), ClientError> {
             let endpoint = DeleteClientConfigurationRequest::builder()
                 .mount(mount)
@@ -118,7 +113,6 @@ pub mod config {
         /// When you have configured Vault with static credentials, you can use this function to have Vault rotate the access key it used.
         ///
         /// See [RotateRootCredentialsRequest]
-        #[instrument(skip(client), err)]
         pub async fn rotate_root_credentials(
             client: &impl Client,
             mount: &str,
@@ -150,7 +144,6 @@ pub mod config {
         /// This configures the way that Vault interacts with the Identity store.
         ///
         /// See [ConfigureIdentityRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn set(
             client: &impl Client,
             mount: &str,
@@ -164,7 +157,6 @@ pub mod config {
         /// Returns the previously configured Identity integration configuration
         ///
         /// See [ReadIdentityConfigurationResponse]
-        #[instrument(skip(client), err)]
         pub async fn read(
             client: &impl Client,
             mount: &str,
@@ -200,7 +192,6 @@ pub mod config {
         /// Registers an AWS public key to be used to verify the instance identity documents.
         ///
         /// See [CreateCertificateConfigurationRequest]
-        #[instrument(skip(client, aws_public_cert, opts), err)]
         pub async fn create(
             client: &impl Client,
             mount: &str,
@@ -222,7 +213,6 @@ pub mod config {
         /// Returns the previously configured AWS public key.
         ///
         /// See [ReadCertificateConfigurationResponse]
-        #[instrument(skip(client), err)]
         pub async fn read(
             client: &impl Client,
             mount: &str,
@@ -239,7 +229,6 @@ pub mod config {
         /// Removes the previously configured AWS public key.
         ///
         /// See [DeleteCertificateConfigurationRequest]
-        #[instrument(skip(client), err)]
         pub async fn delete(
             client: &impl Client,
             mount: &str,
@@ -256,7 +245,6 @@ pub mod config {
         /// Lists all the AWS public certificates that are registered with the method.
         ///
         /// See [ListCertificateConfigurationsResponse]
-        #[instrument(skip(client), err)]
         pub async fn list(
             client: &impl Client,
             mount: &str,
@@ -288,7 +276,6 @@ pub mod config {
         /// Allows the explicit association of STS roles to satellite AWS accounts.
         ///
         /// See [CreateStsRoleRequest]
-        #[instrument(skip(client), err)]
         pub async fn create(
             client: &impl Client,
             mount: &str,
@@ -307,7 +294,6 @@ pub mod config {
         /// Returns the previously configured STS role.
         ///
         /// See [ReadStsRoleResponse]
-        #[instrument(skip(client), err)]
         pub async fn read(
             client: &impl Client,
             mount: &str,
@@ -324,7 +310,6 @@ pub mod config {
         /// Lists all the AWS Account IDs for which an STS role is registered.
         ///
         /// See [ListStsRolesResponse]
-        #[instrument(skip(client), err)]
         pub async fn list(
             client: &impl Client,
             mount: &str,
@@ -336,7 +321,6 @@ pub mod config {
         /// Deletes a previously configured AWS account/STS role association.
         ///
         /// See [DeleteStsRoleRequest]
-        #[instrument(skip(client), err)]
         pub async fn delete(
             client: &impl Client,
             mount: &str,
@@ -373,7 +357,6 @@ pub mod config {
             /// Configures the periodic tidying operation of the access listed identity entries.
             ///
             /// See [ConfigureIdentityAccessListTidyOperationRequest]
-            #[instrument(skip(client, opts), err)]
             pub async fn set(
                 client: &impl Client,
                 mount: &str,
@@ -387,7 +370,6 @@ pub mod config {
             /// Returns the previously configured periodic access list tidying settings.
             ///
             /// See [ReadIdentityAccessListTidySettingsResponse]
-            #[instrument(skip(client), err)]
             pub async fn read(
                 client: &impl Client,
                 mount: &str,
@@ -402,7 +384,6 @@ pub mod config {
             /// Deletes the previously configured periodic access list tidying settings.
             ///
             /// See [DeleteIdentityAccessListTidySettingsRequest]
-            #[instrument(skip(client), err)]
             pub async fn delete(client: &impl Client, mount: &str) -> Result<(), ClientError> {
                 let endpoint = DeleteIdentityAccessListTidySettingsRequest::builder()
                     .mount(mount)
@@ -433,7 +414,6 @@ pub mod config {
             /// Configures the periodic tidying operation of the deny listed role tag entries.
             ///
             /// See [ConfigureRoleTagDenyListTidyOperationRequest]
-            #[instrument(skip(client, opts), err)]
             pub async fn set(
                 client: &impl Client,
                 mount: &str,
@@ -447,7 +427,6 @@ pub mod config {
             /// Returns the previously configured periodic deny list tidying settings.
             ///
             /// See [ReadRoleTagDenyListTidySettingsResponse]
-            #[instrument(skip(client), err)]
             pub async fn read(
                 client: &impl Client,
                 mount: &str,
@@ -462,7 +441,6 @@ pub mod config {
             /// Deletes the previously configured periodic access list tidying settings.
             ///
             /// See [DeleteRoleTagDenyListTidySettingsRequest]
-            #[instrument(skip(client), err)]
             pub async fn delete(client: &impl Client, mount: &str) -> Result<(), ClientError> {
                 let endpoint = DeleteRoleTagDenyListTidySettingsRequest::builder()
                     .mount(mount)
@@ -494,7 +472,6 @@ pub mod role {
     /// Registers a role in the method
     ///
     /// See [CreateRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn create(
         client: &impl Client,
         mount: &str,
@@ -514,7 +491,6 @@ pub mod role {
     /// Returns the previously registered role configuration
     ///
     /// See [ReadRoleResponse]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -531,7 +507,6 @@ pub mod role {
     /// Lists all the roles that are registered with the method
     ///
     /// See [ListRolesResponse]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -540,7 +515,6 @@ pub mod role {
     /// Deletes the previously registered role
     ///
     /// See [DeleteRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, role: &str) -> Result<(), ClientError> {
         let endpoint = DeleteRoleRequest::builder()
             .mount(mount)
@@ -553,7 +527,6 @@ pub mod role {
     /// Creates a role tag on the role
     ///
     /// See [CreateRoleTagRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn create_tag(
         client: &impl Client,
         mount: &str,
@@ -591,7 +564,6 @@ pub mod role_tag_deny_list {
     /// Places a valid role tag in a deny list
     ///
     /// See [PlaceRoleTagsInDenyListRequest]
-    #[instrument(skip(client), err)]
     pub async fn create(
         client: &impl Client,
         mount: &str,
@@ -608,7 +580,6 @@ pub mod role_tag_deny_list {
     /// Returns the deny list entry of a previously deny listed role tag.
     ///
     /// See [ReadRoleTagDenyListResponse]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -625,7 +596,6 @@ pub mod role_tag_deny_list {
     /// Lists all the role tags that are deny listed
     ///
     /// See [ListDenyListTagsResponse]
-    #[instrument(skip(client), err)]
     pub async fn list(
         client: &impl Client,
         mount: &str,
@@ -640,7 +610,6 @@ pub mod role_tag_deny_list {
     /// Deletes a deny listed role tag
     ///
     /// See [DeleteDenyListTagsRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(
         client: &impl Client,
         mount: &str,
@@ -657,7 +626,6 @@ pub mod role_tag_deny_list {
     /// Cleans up the entries in the deny listed based on expiration time on the entry and safety_buffer.
     ///
     /// See [TidyDenyListTagsRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn tidy(
         client: &impl Client,
         mount: &str,
@@ -692,7 +660,6 @@ pub mod identity_access_list {
     /// Returns an entry in the identity access list.
     ///
     /// See [ReadIdentityAccessListInformationResponse]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -725,7 +692,6 @@ pub mod identity_access_list {
     /// Lists all the instance IDs that are in the access list of successful logins
     ///
     /// See [ListIdentityAccessListEntriesResponse]
-    #[instrument(skip(client), err)]
     pub async fn list(
         client: &impl Client,
         mount: &str,
@@ -740,7 +706,6 @@ pub mod identity_access_list {
     /// Cleans up the entries in the access list based on expiration time andsafety_buffer
     ///
     /// See [TidyIdentityAccessListEntriesRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn tidy(
         client: &impl Client,
         mount: &str,

--- a/src/auth/cert.rs
+++ b/src/auth/cert.rs
@@ -7,7 +7,6 @@ use crate::{
 // Fetch a token with policies corresponding to the certificate.
 //
 // See [LoginRequest]
-#[instrument(skip(client), err)]
 pub async fn login(
     client: &impl Client,
     mount: &str,
@@ -41,7 +40,6 @@ pub mod ca_cert_role {
     /// Deletes a CA certificate role.
     ///
     /// See [DeleteCaCertificateRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteCaCertificateRoleRequest::builder()
             .mount(mount)
@@ -54,7 +52,6 @@ pub mod ca_cert_role {
     /// Lists CA certificate roles.
     ///
     /// See [ListCaCertificateRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(
         client: &impl Client,
         mount: &str,
@@ -69,7 +66,6 @@ pub mod ca_cert_role {
     /// Reads information about a CA certificate role.
     ///
     /// See [ReadCaCertificateRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -86,7 +82,6 @@ pub mod ca_cert_role {
     /// Creates a new CA certificate role
     ///
     /// See [CreateCaCertificateRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,

--- a/src/auth/kubernetes.rs
+++ b/src/auth/kubernetes.rs
@@ -13,7 +13,6 @@ use crate::{
 // Configure Kubernetes auth backend.
 //
 // See [ConfigureKubernetesAuthRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn configure(
     client: &impl Client,
     mount: &str,
@@ -34,7 +33,6 @@ pub async fn configure(
 // Configure Kubernetes auth backend.
 //
 // See [ReadKubernetesAuthConfigResponse]
-#[instrument(skip(client), err)]
 pub async fn read_config(
     client: &impl Client,
     mount: &str,
@@ -50,7 +48,6 @@ pub async fn read_config(
 // Fetch a <token with policies using a Kubernetes ServiceAccount.
 //
 // See [LoginWithKubernetesRequest]
-#[instrument(skip(client), err)]
 pub async fn login(
     client: &impl Client,
     mount: &str,
@@ -82,7 +79,6 @@ pub mod role {
     ///
     /// See [ListRolesRequest]
     ///
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -91,7 +87,6 @@ pub mod role {
     /// Reads properties of a Kubernetes role.
     ///
     /// See [ReadKubernetesRoleResponse]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -108,7 +103,6 @@ pub mod role {
     /// Creates a Kubernetes role.
     ///
     /// See [CreateKubernetesRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn create(
         client: &impl Client,
         mount: &str,
@@ -128,7 +122,6 @@ pub mod role {
     /// Deletes an existing Kubernetes role.
     ///
     /// See [DeleteKubernetesRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteKubernetesRoleRequest::builder()
             .mount(mount)

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -14,7 +14,6 @@ use crate::{
 /// Obtain an authorization URL from Vault to start an OIDC login flow
 ///
 /// See [OIDCAuthRequest]
-#[instrument(skip(client), err)]
 pub async fn auth(
     client: &impl Client,
     mount: &str,
@@ -39,7 +38,6 @@ pub async fn auth(
 /// Exchange an authorization code for an OIDC ID Token
 ///
 /// See [OIDCCallbackRequest]
-#[instrument(skip(client), err)]
 pub async fn callback(
     client: &impl Client,
     mount: &str,
@@ -60,7 +58,6 @@ pub async fn callback(
 /// Fetch a token using a JWT token
 ///
 /// See [JWTLoginRequest]
-#[instrument(skip(client), err)]
 pub async fn login(
     client: &impl Client,
     mount: &str,
@@ -93,7 +90,6 @@ pub mod config {
     /// Read the configuration of the mounted KV engine
     ///
     /// See [ReadConfigurationResponse]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -108,7 +104,6 @@ pub mod config {
     /// Update the configuration of the mounted KV engine
     ///
     /// See [SetConfigurationRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -135,7 +130,6 @@ pub mod role {
     /// Deletes a role
     ///
     /// See [DeleteRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteRoleRequest::builder()
             .mount(mount)
@@ -148,7 +142,6 @@ pub mod role {
     /// Lists all roles
     ///
     /// See [ListRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -157,7 +150,6 @@ pub mod role {
     /// Reads a role
     ///
     /// See [ReadRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -174,7 +166,6 @@ pub mod role {
     /// Creates or updates a role
     ///
     /// See [SetRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,

--- a/src/auth/userpass.rs
+++ b/src/auth/userpass.rs
@@ -7,7 +7,6 @@ use crate::{
 // Fetch a token with policies corresponding to the username.
 //
 // See [LoginRequest]
-#[instrument(skip(client, password), err)]
 pub async fn login(
     client: &impl Client,
     mount: &str,
@@ -43,7 +42,6 @@ pub mod user {
     /// Deletes a user.
     ///
     /// See [DeleteUserRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(
         client: &impl Client,
         mount: &str,
@@ -60,7 +58,6 @@ pub mod user {
     /// Lists users.
     ///
     /// See [ListUsersRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListUsersResponse, ClientError> {
         let endpoint = ListUsersRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -69,7 +66,6 @@ pub mod user {
     /// Reads information about a user.
     ///
     /// See [ReadUserRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -86,7 +82,6 @@ pub mod user {
     /// Crates or updates a new user.
     ///
     /// See [CreateUserRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -108,7 +103,6 @@ pub mod user {
     /// Updates a user's password.
     ///
     /// See [UpdatePasswordRequest]
-    #[instrument(skip(client, password), err)]
     pub async fn update_password(
         client: &impl Client,
         mount: &str,
@@ -127,7 +121,6 @@ pub mod user {
     /// Updates a user's policies.
     ///
     /// See [UpdatePoliciesRequest]
-    #[instrument(skip(client), err)]
     pub async fn update_policies(
         client: &impl Client,
         mount: &str,

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -21,7 +21,6 @@ pub mod config {
     /// Configures the root IAM credentials to communicate with AWS.
     ///
     /// See [SetConfigurationRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -41,7 +40,6 @@ pub mod config {
         api::exec_with_empty(client, endpoint).await
     }
 
-    #[instrument(skip(client), err)]
     pub async fn get(
         client: &impl Client,
         mount: &str,
@@ -54,7 +52,6 @@ pub mod config {
         api::exec_with_result(client, e).await
     }
 
-    #[instrument(skip(client), err)]
     pub async fn rotate(
         client: &impl Client,
         mount: &str,
@@ -70,7 +67,6 @@ pub mod config {
     /// Configures the root IAM credentials to communicate with AWS.
     ///
     /// See [SetConfigurationRequest]
-    #[instrument(skip(client), err)]
     pub async fn set_lease(
         client: &impl Client,
         mount: &str,
@@ -87,7 +83,6 @@ pub mod config {
         api::exec_with_empty(client, endpoint).await
     }
 
-    #[instrument(skip(client), err)]
     pub async fn read_lease(
         client: &impl Client,
         mount: &str,
@@ -117,7 +112,6 @@ pub mod roles {
         error::ClientError,
     };
 
-    #[instrument(skip(client, opts), err)]
     pub async fn create_update(
         client: &impl Client,
         mount: &str,

--- a/src/database.rs
+++ b/src/database.rs
@@ -14,7 +14,6 @@ pub mod connection {
     /// Creates or updates a PostgreSQL connection
     ///
     /// See [PostgreSQLConnectionRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn postgres(
         client: &impl Client,
         mount: &str,
@@ -34,7 +33,6 @@ pub mod connection {
     /// Deletes a connection
     ///
     /// See [DeleteConnectionRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteConnectionRequest::builder()
             .mount(mount)
@@ -47,7 +45,6 @@ pub mod connection {
     /// Lists all connections
     ///
     /// See [ListConnectionsRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(
         client: &impl Client,
         mount: &str,
@@ -62,7 +59,6 @@ pub mod connection {
     /// Reads a connection
     ///
     /// See [ReadConnectionRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -79,7 +75,6 @@ pub mod connection {
     /// Reset a connection
     ///
     /// See [ResetConnectionRequest]
-    #[instrument(skip(client), err)]
     pub async fn reset(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = ResetConnectionRequest::builder()
             .mount(mount)
@@ -92,7 +87,6 @@ pub mod connection {
     /// Rotates the root account configured in a connection
     ///
     /// See [RotateRootRequest]
-    #[instrument(skip(client), err)]
     pub async fn rotate(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = RotateRootRequest::builder()
             .mount(mount)
@@ -118,7 +112,6 @@ pub mod role {
     /// Generates credentials from a role
     ///
     /// See [GenerateCredentialsRequest]
-    #[instrument(skip(client), err)]
     pub async fn creds(
         client: &impl Client,
         mount: &str,
@@ -135,7 +128,6 @@ pub mod role {
     /// Deletes a role
     ///
     /// See [DeleteRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteRoleRequest::builder()
             .mount(mount)
@@ -148,7 +140,6 @@ pub mod role {
     /// Lists all roles
     ///
     /// See [ListRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -157,7 +148,6 @@ pub mod role {
     /// Reads a role
     ///
     /// See [ReadRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -174,7 +164,6 @@ pub mod role {
     /// Creates or updates a role
     ///
     /// See [SetRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -210,7 +199,6 @@ pub mod static_role {
     /// Generates credentials from a static role
     ///
     /// See [GetStaticCredentialsRequest]
-    #[instrument(skip(client), err)]
     pub async fn creds(
         client: &impl Client,
         mount: &str,
@@ -227,7 +215,6 @@ pub mod static_role {
     /// Deletes a static role
     ///
     /// See [DeleteStaticRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteStaticRoleRequest::builder()
             .mount(mount)
@@ -240,7 +227,6 @@ pub mod static_role {
     /// Lists all static roles
     ///
     /// See [ListStaticRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(
         client: &impl Client,
         mount: &str,
@@ -255,7 +241,6 @@ pub mod static_role {
     /// Reads a static role
     ///
     /// See [ReadStaticRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -272,7 +257,6 @@ pub mod static_role {
     /// Rotates the credentials associated with a static role
     ///
     /// See [RotateStaticRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn rotate(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = RotateStaticRoleRequest::builder()
             .mount(mount)
@@ -285,7 +269,6 @@ pub mod static_role {
     /// Creates or updates a static role
     ///
     /// See [SetStaticRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,

--- a/src/identity/entity.rs
+++ b/src/identity/entity.rs
@@ -24,7 +24,6 @@ use crate::{
 /// Create an entity.
 ///
 /// See [CreateEntityRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn create(
     client: &impl Client,
     opts: Option<&mut CreateEntityRequestBuilder>,
@@ -37,7 +36,6 @@ pub async fn create(
 /// Reads entity by `id`.
 ///
 /// See [ReadEntityByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn read_by_id(
     client: &impl Client,
     id: &str,
@@ -50,7 +48,6 @@ pub async fn read_by_id(
 /// Update entity by `id`.
 ///
 /// See [UpdateEntityByIdRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn update_by_id(
     client: &impl Client,
     id: &str,
@@ -64,7 +61,6 @@ pub async fn update_by_id(
 /// Delete entity by `id`.
 ///
 /// See [DeleteEntityByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientError> {
     let endpoint = DeleteEntityByIdRequest::builder().id(id).build().unwrap();
     api::exec_with_empty(client, endpoint).await
@@ -73,7 +69,6 @@ pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientEr
 /// Batch delete entity.
 ///
 /// See [BatchDeleteRequest]
-#[instrument(skip(client), err)]
 pub async fn batch_delete<T: fmt::Debug + Into<Vec<String>>>(
     client: &impl Client,
     entity_ids: T,
@@ -88,7 +83,6 @@ pub async fn batch_delete<T: fmt::Debug + Into<Vec<String>>>(
 /// List entities by ID.
 ///
 /// See [ListEntitiesByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn list_by_id(client: &impl Client) -> Result<ListEntitiesByIdResponse, ClientError> {
     let endpoint = ListEntitiesByIdRequest::builder().build().unwrap();
     api::exec_with_result(client, endpoint).await
@@ -97,7 +91,6 @@ pub async fn list_by_id(client: &impl Client) -> Result<ListEntitiesByIdResponse
 /// Creates or update an entity with the given `name`.
 ///
 /// See [CreateEntityByNameRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn create_or_update_by_name(
     client: &impl Client,
     name: &str,
@@ -111,7 +104,6 @@ pub async fn create_or_update_by_name(
 /// Reads entity by `name`.
 ///
 /// See [ReadEntityByNameRequest]
-#[instrument(skip(client), err)]
 pub async fn read_by_name(
     client: &impl Client,
     name: &str,
@@ -127,7 +119,6 @@ pub async fn read_by_name(
 /// Delete entity by `name`.
 ///
 /// See [DeleteEntityByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_by_name(client: &impl Client, name: &str) -> Result<(), ClientError> {
     let endpoint = DeleteEntityByNameRequest::builder()
         .name(name)
@@ -139,7 +130,6 @@ pub async fn delete_by_name(client: &impl Client, name: &str) -> Result<(), Clie
 /// List entities by Name.
 ///
 /// See [ListEntitiesByNameRequest]
-#[instrument(skip(client), err)]
 pub async fn list_by_name(client: &impl Client) -> Result<ListEntitiesByNameResponse, ClientError> {
     let endpoint = ListEntitiesByNameRequest::builder().build().unwrap();
     api::exec_with_result(client, endpoint).await
@@ -148,7 +138,6 @@ pub async fn list_by_name(client: &impl Client) -> Result<ListEntitiesByNameResp
 /// Merge entities.
 ///
 /// See [MergeEntitiesRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn merge(
     client: &impl Client,
     from_entity_ids: Vec<String>,

--- a/src/identity/entity_alias.rs
+++ b/src/identity/entity_alias.rs
@@ -21,7 +21,6 @@ use crate::{
 /// Create or update an entity alias.
 ///
 /// See [ CreateEntityAliasRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn create(
     client: &impl Client,
     name: &str,
@@ -56,7 +55,6 @@ pub async fn create(
 /// Reads entity alias by `id`.
 ///
 /// See [ReadEntityAliasByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn read_by_id(
     client: &impl Client,
     id: &str,
@@ -72,7 +70,6 @@ pub async fn read_by_id(
 /// Update entity_alias by `id`.
 ///
 /// See [UpdateEntityAliasByIdRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn update_by_id(
     client: &impl Client,
     id: &str,
@@ -86,7 +83,6 @@ pub async fn update_by_id(
 /// Delete entity alias by `id`.
 ///
 /// See [DeleteEntityAliasByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientError> {
     let endpoint = DeleteEntityAliasByIdRequest::builder()
         .id(id)
@@ -98,7 +94,6 @@ pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientEr
 /// List entity aliases by ID.
 ///
 /// See [ListEntityAliasesByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn list_by_id(
     client: &impl Client,
 ) -> Result<ListEntityAliasesByIdResponse, ClientError> {

--- a/src/identity/group.rs
+++ b/src/identity/group.rs
@@ -21,7 +21,6 @@ use crate::{
 /// Creates a group.
 ///
 /// See [CreateGroupRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn create(
     client: &impl Client,
     opts: Option<&mut CreateGroupRequestBuilder>,
@@ -34,7 +33,6 @@ pub async fn create(
 /// Reads group by `id`.
 ///
 /// See [ReadGroupByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn read_by_id(
     client: &impl Client,
     id: &str,
@@ -47,7 +45,6 @@ pub async fn read_by_id(
 /// Reads group by `name`.
 ///
 /// See [ReadGroupByNameRequest]
-#[instrument(skip(client), err)]
 pub async fn read_by_name(
     client: &impl Client,
     name: &str,
@@ -62,7 +59,6 @@ pub async fn read_by_name(
 /// Update group by `id`.
 ///
 /// See [UpdateGroupByIdRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn update_by_id(
     client: &impl Client,
     id: &str,
@@ -76,7 +72,6 @@ pub async fn update_by_id(
 /// Delete group by `id`.
 ///
 /// See [DeleteGroupByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientError> {
     let endpoint = DeleteGroupByIdRequest::builder().id(id).build().unwrap();
     api::exec_with_empty(client, endpoint).await
@@ -85,7 +80,6 @@ pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientEr
 /// List groups by ID.
 ///
 /// See [ListGroupsByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn list_by_id(client: &impl Client) -> Result<ListGroupsByIdResponse, ClientError> {
     let endpoint = ListGroupsByIdRequest::builder().build().unwrap();
     api::exec_with_result(client, endpoint).await
@@ -93,7 +87,6 @@ pub async fn list_by_id(client: &impl Client) -> Result<ListGroupsByIdResponse, 
 /// Creates or update an group with the given `name`.
 ///
 /// See [CreateGroupByNameRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn create_or_update_by_name(
     client: &impl Client,
     name: &str,
@@ -107,7 +100,6 @@ pub async fn create_or_update_by_name(
 /// Delete group by `name`.
 ///
 /// See [DeleteGroupByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_by_name(client: &impl Client, name: &str) -> Result<(), ClientError> {
     let endpoint = DeleteGroupByNameRequest::builder()
         .name(name)
@@ -119,7 +111,6 @@ pub async fn delete_by_name(client: &impl Client, name: &str) -> Result<(), Clie
 /// List entities by Name.
 ///
 /// See [ListGroupsByNameRequest]
-#[instrument(skip(client), err)]
 pub async fn list_by_name(client: &impl Client) -> Result<ListGroupsByNameResponse, ClientError> {
     let endpoint = ListGroupsByNameRequest::builder().build().unwrap();
     api::exec_with_result(client, endpoint).await

--- a/src/identity/group_alias.rs
+++ b/src/identity/group_alias.rs
@@ -17,7 +17,6 @@ use crate::{
     error::ClientError,
 };
 
-#[instrument(skip(client, opts), err)]
 pub async fn create(
     client: &impl Client,
     name: &str,
@@ -50,7 +49,6 @@ pub async fn create(
 /// Reads group alias by `id`.
 ///
 /// See [ReadGroupAliasByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn read_by_id(
     client: &impl Client,
     id: &str,
@@ -63,7 +61,6 @@ pub async fn read_by_id(
 /// Update group alias by `id`.
 ///
 /// See [UpdateGroupAliasByIdRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn update_by_id(
     client: &impl Client,
     id: &str,
@@ -83,7 +80,6 @@ pub async fn update_by_id(
 /// Delete group alias by `id`.
 ///
 /// See [DeleteGroupAliasByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientError> {
     let endpoint = DeleteGroupAliasByIdRequest::builder()
         .id(id)
@@ -95,7 +91,6 @@ pub async fn delete_by_id(client: &impl Client, id: &str) -> Result<(), ClientEr
 /// List groups aliases by ID.
 ///
 /// See [ListGroupAliasesByIdRequest]
-#[instrument(skip(client), err)]
 pub async fn list_by_id(client: &impl Client) -> Result<ListGroupAliasesByIdResponse, ClientError> {
     let endpoint = ListGroupAliasesByIdRequest::builder().build().unwrap();
     api::exec_with_result(client, endpoint).await

--- a/src/kv1.rs
+++ b/src/kv1.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 ///
 /// A key called ttl will trigger some special behavior. See the [Vault KV secrets engine documentation][<https://developer.hashicorp.com/vault/docs/secrets/kv>] for details.
 /// See [SetSecretRequest][crate::api::kv1::requests::SetSecretRequest]
-#[instrument(skip(client, data), err)]
 pub async fn set<T: Serialize>(
     client: &impl Client,
     mount: &str,
@@ -47,7 +46,6 @@ pub async fn set<T: Serialize>(
 /// Get value of the secret at given path.
 /// Return the deserialized HashMap of secret directly,
 /// if you need to access additional fields such as lead_duration, use [get_raw]
-#[instrument(skip(client), err)]
 pub async fn get<D: DeserializeOwned>(
     client: &impl Client,
     mount: &str,
@@ -66,7 +64,6 @@ pub async fn get<D: DeserializeOwned>(
 
 /// Get value of the secret at given path, returning the raw response without deserialization
 /// Additional fields are available on raw response, such as lease_duration
-#[instrument(skip(client), err)]
 pub async fn get_raw(
     client: &impl Client,
     mount: &str,
@@ -84,7 +81,6 @@ pub async fn get_raw(
 /// List secret keys at given location, returning raw server response
 ///
 /// See [ListSecretRequest]
-#[instrument(skip(client), err)]
 pub async fn list(
     client: &impl Client,
     mount: &str,
@@ -102,7 +98,6 @@ pub async fn list(
 /// Delete secret at given location
 ///
 /// See [DeleteSecretRequest]
-#[instrument(skip(client), err)]
 pub async fn delete(client: &impl Client, mount: &str, path: &str) -> Result<(), ClientError> {
     let endpoint = DeleteSecretRequest::builder()
         .mount(mount)

--- a/src/kv2.rs
+++ b/src/kv2.rs
@@ -20,7 +20,6 @@ use serde::{de::DeserializeOwned, Serialize};
 /// Soft-delete the latest version of a secret
 ///
 /// See [DeleteLatestSecretVersionRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_latest(
     client: &impl Client,
     mount: &str,
@@ -37,7 +36,6 @@ pub async fn delete_latest(
 /// Delete all metadata and versions of a secret
 ///
 /// See [DeleteSecretMetadataRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_metadata(
     client: &impl Client,
     mount: &str,
@@ -54,7 +52,6 @@ pub async fn delete_metadata(
 /// Soft-delete specific versions of a secret
 ///
 /// See [DeleteSecretVersionsRequest]
-#[instrument(skip(client), err)]
 pub async fn delete_versions(
     client: &impl Client,
     mount: &str,
@@ -73,7 +70,6 @@ pub async fn delete_versions(
 /// Permanently delete specific versions of a secret
 ///
 /// See [DestroySecretVersionsRequest]
-#[instrument(skip(client), err)]
 pub async fn destroy_versions(
     client: &impl Client,
     mount: &str,
@@ -92,7 +88,6 @@ pub async fn destroy_versions(
 /// Lists all secret keys at the given path
 ///
 /// See [ListSecretsRequest]
-#[instrument(skip(client), err)]
 pub async fn list(
     client: &impl Client,
     mount: &str,
@@ -109,7 +104,6 @@ pub async fn list(
 /// Reads the value of the secret at the given path
 ///
 /// See [ReadSecretRequest]
-#[instrument(skip(client), err)]
 pub async fn read<D: DeserializeOwned>(
     client: &impl Client,
     mount: &str,
@@ -127,7 +121,6 @@ pub async fn read<D: DeserializeOwned>(
 /// Reads the metadata of the secret at the given path
 ///
 /// See [ReadSecretMetadataRequest]
-#[instrument(skip(client), err)]
 pub async fn read_metadata(
     client: &impl Client,
     mount: &str,
@@ -144,7 +137,6 @@ pub async fn read_metadata(
 /// Reads the value of the secret at the given version and path
 ///
 /// See [ReadSecretRequest]
-#[instrument(skip(client), err)]
 pub async fn read_version<D: DeserializeOwned>(
     client: &impl Client,
     mount: &str,
@@ -164,7 +156,6 @@ pub async fn read_version<D: DeserializeOwned>(
 /// Sets the value of the secret at the given path
 ///
 /// See [SetSecretRequest]
-#[instrument(skip(client, data), err)]
 pub async fn set<T: Serialize>(
     client: &impl Client,
     mount: &str,
@@ -187,7 +178,6 @@ pub async fn set<T: Serialize>(
 /// including an argument for [SetSecretRequestOptions]
 ///
 /// See [SetSecretRequest]
-#[instrument(skip(client, data), err)]
 pub async fn set_with_options<T: Serialize>(
     client: &impl Client,
     mount: &str,
@@ -211,7 +201,6 @@ pub async fn set_with_options<T: Serialize>(
 /// Sets the value of the secret at the given path
 ///
 /// See [SetSecretMetadataRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn set_metadata(
     client: &impl Client,
     mount: &str,
@@ -231,7 +220,6 @@ pub async fn set_metadata(
 /// Undelete specific versions of a secret
 ///
 /// See [UndeleteSecretVersionsRequest]
-#[instrument(skip(client), err)]
 pub async fn undelete_versions(
     client: &impl Client,
     mount: &str,
@@ -266,7 +254,6 @@ pub mod config {
     /// Read the configuration of the mounted KV engine
     ///
     /// See [ReadConfigurationResponse]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -281,7 +268,6 @@ pub mod config {
     /// Update the configuration of the mounted KV engine
     ///
     /// See [SetConfigurationRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -13,7 +13,6 @@ pub mod cert {
     /// Generates a certificate using the given role and options
     ///
     /// See [GenerateCertificateRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn generate(
         client: &impl Client,
         mount: &str,
@@ -33,7 +32,6 @@ pub mod cert {
     /// Lists all certificates
     ///
     /// See [ListCertificatesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<Vec<String>, ClientError> {
         let endpoint = ListCertificatesRequest::builder()
             .mount(mount)
@@ -45,7 +43,6 @@ pub mod cert {
     /// Read a certificate using its serial
     ///
     /// See [ReadCertificateRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -62,7 +59,6 @@ pub mod cert {
     /// Revokes a certificate using its serial
     ///
     /// See [RevokeCertificateRequest]
-    #[instrument(skip(client), err)]
     pub async fn revoke(
         client: &impl Client,
         mount: &str,
@@ -79,7 +75,6 @@ pub mod cert {
     /// Tidy's up the certificate backend
     ///
     /// See [TidyRequest]
-    #[instrument(skip(client), err)]
     pub async fn tidy(client: &impl Client, mount: &str) -> Result<(), ClientError> {
         let endpoint = TidyRequest::builder().mount(mount).build().unwrap();
         api::exec_with_empty_result(client, endpoint).await
@@ -106,7 +101,6 @@ pub mod cert {
         /// Delete's the root CA
         ///
         /// See [DeleteRootRequest]
-        #[instrument(skip(client), err)]
         pub async fn delete(client: &impl Client, mount: &str) -> Result<(), ClientError> {
             let endpoint = DeleteRootRequest::builder().mount(mount).build().unwrap();
             api::exec_with_empty(client, endpoint).await
@@ -115,7 +109,6 @@ pub mod cert {
         /// Generates a new root CA
         ///
         /// See [GenerateRootRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn generate(
             client: &impl Client,
             mount: &str,
@@ -135,7 +128,6 @@ pub mod cert {
         /// Signs a certificate using the root CA
         ///
         /// See [SignCertificateRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn sign(
             client: &impl Client,
             mount: &str,
@@ -159,7 +151,6 @@ pub mod cert {
         /// Signs an intermediate CA using the root CA
         ///
         /// See [SignIntermediateRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn sign_intermediate(
             client: &impl Client,
             mount: &str,
@@ -181,7 +172,6 @@ pub mod cert {
         /// Signs a self issued certificate using the root CA
         ///
         /// See [SignSelfIssuedRequest]
-        #[instrument(skip(client, certificate), err)]
         pub async fn sign_self_issued(
             client: &impl Client,
             mount: &str,
@@ -198,7 +188,6 @@ pub mod cert {
         /// Configures the root CA
         ///
         /// See [SubmitCARequest]
-        #[instrument(skip(client, pem_bundle), err)]
         pub async fn submit(
             client: &impl Client,
             mount: &str,
@@ -229,7 +218,6 @@ pub mod cert {
             /// Generates an intermediate CA
             ///
             /// See [GenerateIntermediateRequest]
-            #[instrument(skip(client, opts), err)]
             pub async fn generate(
                 client: &impl Client,
                 mount: &str,
@@ -251,7 +239,6 @@ pub mod cert {
             /// Sets the signed CA certificate
             ///
             /// See [SetSignedIntermediateRequest]
-            #[instrument(skip(client, certificate), err)]
             pub async fn set_signed(
                 client: &impl Client,
                 mount: &str,
@@ -282,7 +269,6 @@ pub mod cert {
         /// Rotates the CRL
         ///
         /// See [RotateCRLsRequest]
-        #[instrument(skip(client), err)]
         pub async fn rotate(
             client: &impl Client,
             mount: &str,
@@ -294,7 +280,6 @@ pub mod cert {
         /// Reads the CRL configuration
         ///
         /// See [ReadCRLConfigRequest]
-        #[instrument(skip(client), err)]
         pub async fn read_config(
             client: &impl Client,
             mount: &str,
@@ -309,7 +294,6 @@ pub mod cert {
         /// Sets the CRL configuration
         ///
         /// See [SetCRLConfigRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn set_config(
             client: &impl Client,
             mount: &str,
@@ -333,7 +317,6 @@ pub mod cert {
         /// Reads the configured certificate URLs
         ///
         /// See [ReadURLsRequest]
-        #[instrument(skip(client), err)]
         pub async fn read(
             client: &impl Client,
             mount: &str,
@@ -345,7 +328,6 @@ pub mod cert {
         /// Sets the configured certificate URLs
         ///
         /// See [SetURLsRequest]
-        #[instrument(skip(client, opts), err)]
         pub async fn set(
             client: &impl Client,
             mount: &str,
@@ -373,7 +355,6 @@ pub mod role {
     /// Deletes a role
     ///
     /// See [DeleteRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteRoleRequest::builder()
             .mount(mount)
@@ -386,7 +367,6 @@ pub mod role {
     /// Lists all roles
     ///
     /// See [ListRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -395,7 +375,6 @@ pub mod role {
     /// Reads a role
     ///
     /// See [ReadRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -412,7 +391,6 @@ pub mod role {
     /// Creates or updates a role
     ///
     /// See [SetRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -7,7 +7,6 @@ use crate::error::ClientError;
 /// Generates SSH credentials for the given role
 ///
 /// See [GenerateSSHCredsRequest]
-#[instrument(skip(client), err)]
 pub async fn generate(
     client: &impl Client,
     mount: &str,
@@ -29,7 +28,6 @@ pub async fn generate(
 /// Verify SSH OTP details
 ///
 /// See [VerifySSHOTPRequest]
-#[instrument(skip(client), err)]
 pub async fn verify_otp(
     client: &impl Client,
     mount: &str,
@@ -58,7 +56,6 @@ pub mod ca {
     /// Deletes the stored keys for the CA.
     ///
     /// See [DeleteCAInfoRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str) -> Result<(), ClientError> {
         let endpoint = DeleteCAInfoRequest::builder().mount(mount).build().unwrap();
         api::exec_with_empty(client, endpoint).await
@@ -67,7 +64,6 @@ pub mod ca {
     /// Generates CA certificate internally and returns the public key.
     ///
     /// See [SubmitCAInfoRequest]
-    #[instrument(skip(client), err)]
     pub async fn generate(
         client: &impl Client,
         mount: &str,
@@ -83,7 +79,6 @@ pub mod ca {
     /// Reads the public key of the CA.
     ///
     /// See [ReadPublicKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -98,7 +93,6 @@ pub mod ca {
     /// Signs a public key using the CA certificate.
     ///
     /// See [SignSSHKeyRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn sign(
         client: &impl Client,
         mount: &str,
@@ -120,7 +114,6 @@ pub mod ca {
     /// Sets the private and public key for the CA.
     ///
     /// See [SubmitCAInfoRequest]
-    #[instrument(skip(client, private_key), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -146,7 +139,6 @@ pub mod key {
     /// Creates or updates a SSH key
     ///
     /// See [SetKeyRequest]
-    #[instrument(skip(client, key), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -165,7 +157,6 @@ pub mod key {
     /// Deletes a SSH key
     ///
     /// See [DeleteKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteKeyRequest::builder()
             .mount(mount)
@@ -193,7 +184,6 @@ pub mod role {
     /// Deletes a role
     ///
     /// See [DeleteRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteRoleRequest::builder()
             .mount(mount)
@@ -206,7 +196,6 @@ pub mod role {
     /// Lists all roles
     ///
     /// See [ListRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListRolesResponse, ClientError> {
         let endpoint = ListRolesRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -215,7 +204,6 @@ pub mod role {
     /// Lists all roles by IP
     ///
     /// See [ListRolesByIPRequest]
-    #[instrument(skip(client), err)]
     pub async fn list_by_ip(
         client: &impl Client,
         mount: &str,
@@ -232,7 +220,6 @@ pub mod role {
     /// Reads a role
     ///
     /// See [ReadRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -249,7 +236,6 @@ pub mod role {
     /// Creates or updates a role
     ///
     /// See [SetRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,
@@ -280,7 +266,6 @@ pub mod zero {
     /// Deletes all zero-address roles
     ///
     /// See [DeleteZeroAddressRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str) -> Result<(), ClientError> {
         let endpoint = DeleteZeroAddressRolesRequest::builder()
             .mount(mount)
@@ -292,7 +277,6 @@ pub mod zero {
     /// Lists all zero-address roles
     ///
     /// See [ListZeroAddressRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(
         client: &impl Client,
         mount: &str,
@@ -307,7 +291,6 @@ pub mod zero {
     /// Sets zero-address roles
     ///
     /// See [ConfigureZeroAddressRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn set(
         client: &impl Client,
         mount: &str,

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -28,7 +28,6 @@ pub enum ServerStatus {
 /// Returns health information about the Vault server.
 ///
 /// See [ReadHealthRequest]
-#[instrument(skip(client), err)]
 pub async fn health(client: &impl Client) -> Result<ReadHealthResponse, ClientError> {
     let endpoint = ReadHealthRequest::builder().build().unwrap();
     api::exec_with_no_result(client, endpoint).await
@@ -37,7 +36,6 @@ pub async fn health(client: &impl Client) -> Result<ReadHealthResponse, ClientEr
 /// Initialize a new Vault. The Vault must not have been previously initialized.
 ///
 /// See [StartInitializationRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn start_initialization(
     client: &impl Client,
     secret_shares: u64,
@@ -57,7 +55,6 @@ pub async fn start_initialization(
 /// Seals the Vault server.
 ///
 /// See [SealRequest]
-#[instrument(skip(client), err)]
 pub async fn seal(client: &impl Client) -> Result<(), ClientError> {
     let endpoint = SealRequest::builder().build().unwrap();
     api::exec_with_empty(client, endpoint).await
@@ -66,7 +63,6 @@ pub async fn seal(client: &impl Client) -> Result<(), ClientError> {
 /// Unseals the Vault server.
 ///
 /// See [UnsealRequest]
-#[instrument(skip(client, key), err)]
 pub async fn unseal(
     client: &impl Client,
     key: Option<String>,
@@ -85,7 +81,6 @@ pub async fn unseal(
 /// Returns the status of the Vault server.
 ///
 /// See [ReadHealthRequest]
-#[instrument(skip(client), err)]
 pub async fn status(client: &impl Client) -> Result<ServerStatus, ClientError> {
     let result = health(client).await;
     match result {
@@ -133,7 +128,6 @@ pub mod auth {
     /// Enables an auth engine at the given path
     ///
     /// See [EnableAuthRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn enable(
         client: &impl Client,
         path: &str,
@@ -153,7 +147,6 @@ pub mod auth {
     /// Lists all mounted auth engines
     ///
     /// See [ListAuthsRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client) -> Result<HashMap<String, AuthResponse>, ClientError> {
         let endpoint = ListAuthsRequest::builder().build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -174,7 +167,6 @@ pub mod mount {
     /// Enables a secret engine at the given path
     ///
     /// See [EnableEngineRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn enable(
         client: &impl Client,
         path: &str,
@@ -194,7 +186,6 @@ pub mod mount {
     /// Lists all mounted secret engines
     ///
     /// See [ListMountsRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client) -> Result<HashMap<String, MountResponse>, ClientError> {
         let endpoint = ListMountsRequest::builder().build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -220,7 +211,6 @@ pub mod policy {
     /// Deletes the given policy.
     ///
     /// See [DeletePolicyRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, name: &str) -> Result<(), ClientError> {
         let endpoint = DeletePolicyRequest::builder().name(name).build().unwrap();
         api::exec_with_empty(client, endpoint).await
@@ -229,7 +219,6 @@ pub mod policy {
     /// Lists all configured policies.
     ///
     /// See [ListPoliciesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client) -> Result<ListPoliciesResponse, ClientError> {
         let endpoint = ListPoliciesRequest::builder().build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -238,7 +227,6 @@ pub mod policy {
     /// Reads the given policy.
     ///
     /// See [ReadPolicyRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(client: &impl Client, name: &str) -> Result<ReadPolicyResponse, ClientError> {
         let endpoint = ReadPolicyRequest::builder().name(name).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -247,7 +235,6 @@ pub mod policy {
     /// Sets the given policy.
     ///
     /// See [CreatePolicyRequest]
-    #[instrument(skip(client), err)]
     pub async fn set(client: &impl Client, name: &str, policy: &str) -> Result<(), ClientError> {
         let endpoint = CreatePolicyRequest::builder()
             .name(name)
@@ -276,7 +263,6 @@ pub mod wrapping {
     /// Looks up information about a token wrapping response
     ///
     /// See [WrappingLookupResponse]
-    #[instrument(skip(client), err)]
     pub async fn lookup(
         client: &impl Client,
         token: &str,
@@ -291,7 +277,6 @@ pub mod wrapping {
     /// Unwraps a token wrapped response
     ///
     /// See [UnwrapRequest]
-    #[instrument(skip(client), err)]
     pub async fn unwrap<D: DeserializeOwned>(
         client: &impl Client,
         token: Option<&str>,

--- a/src/token.rs
+++ b/src/token.rs
@@ -21,7 +21,6 @@ use crate::{
 /// Looks up a token
 ///
 /// See [LookupTokenResponse]
-#[instrument(skip(client), err)]
 pub async fn lookup(client: &impl Client, token: &str) -> Result<LookupTokenResponse, ClientError> {
     let endpoint = LookupTokenRequest::builder().token(token).build().unwrap();
     api::exec_with_result(client, endpoint).await
@@ -30,7 +29,6 @@ pub async fn lookup(client: &impl Client, token: &str) -> Result<LookupTokenResp
 /// Looks up a token by its accessor ID
 ///
 /// See [LookupTokenAccessorRequest]
-#[instrument(skip(client), err)]
 pub async fn lookup_accessor(
     client: &impl Client,
     accessor: &str,
@@ -45,7 +43,6 @@ pub async fn lookup_accessor(
 /// Looks up the token being sent in the header of this request
 ///
 /// See [LookupTokenSelfRequest]
-#[instrument(skip(client), err)]
 pub async fn lookup_self(client: &impl Client) -> Result<LookupTokenResponse, ClientError> {
     let endpoint = LookupTokenSelfRequest::builder().build().unwrap();
     api::exec_with_result(client, endpoint).await
@@ -54,7 +51,6 @@ pub async fn lookup_self(client: &impl Client) -> Result<LookupTokenResponse, Cl
 /// Creates a new token
 ///
 /// See [CreateTokenRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn new(
     client: &impl Client,
     opts: Option<&mut CreateTokenRequestBuilder>,
@@ -67,7 +63,6 @@ pub async fn new(
 /// Creates a new orphan token
 ///
 /// See [CreateOrphanTokenRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn new_orphan(
     client: &impl Client,
     opts: Option<&mut CreateOrphanTokenRequestBuilder>,
@@ -80,7 +75,6 @@ pub async fn new_orphan(
 /// Creates a new token based on a role
 ///
 /// See [CreateRoleTokenRequest]
-#[instrument(skip(client, opts), err)]
 pub async fn new_role(
     client: &impl Client,
     role: &str,
@@ -94,7 +88,6 @@ pub async fn new_role(
 /// Renews a token
 ///
 /// See [RenewTokenRequest]
-#[instrument(skip(client), err)]
 pub async fn renew(
     client: &impl Client,
     token: &str,
@@ -110,7 +103,6 @@ pub async fn renew(
 /// Renews the token by its accessor ID
 ///
 /// See [RenewTokenAccessorRequest]
-#[instrument(skip(client), err)]
 pub async fn renew_accessor(
     client: &impl Client,
     accessor: &str,
@@ -126,7 +118,6 @@ pub async fn renew_accessor(
 /// Renews the token being sent in the header of this request
 ///
 /// See [RenewTokenSelfRequest]
-#[instrument(skip(client), err)]
 pub async fn renew_self(
     client: &impl Client,
     increment: Option<&str>,
@@ -141,7 +132,6 @@ pub async fn renew_self(
 /// Revokes a token
 ///
 /// See [RevokeTokenRequest]
-#[instrument(skip(client), err)]
 pub async fn revoke(client: &impl Client, token: &str) -> Result<(), ClientError> {
     let endpoint = RevokeTokenRequest::builder().token(token).build().unwrap();
     api::exec_with_empty(client, endpoint).await
@@ -150,7 +140,6 @@ pub async fn revoke(client: &impl Client, token: &str) -> Result<(), ClientError
 /// Revokes a token by its accessor ID
 ///
 /// See [RevokeTokenAccessorRequest]
-#[instrument(skip(client), err)]
 pub async fn revoke_accessor(client: &impl Client, accessor: &str) -> Result<(), ClientError> {
     let endpoint = RevokeTokenAccessorRequest::builder()
         .accessor(accessor)
@@ -162,7 +151,6 @@ pub async fn revoke_accessor(client: &impl Client, accessor: &str) -> Result<(),
 /// Revokes a token excluding any child tokens
 ///
 /// See [RevokeTokenOrphanRequest]
-#[instrument(skip(client), err)]
 pub async fn revoke_orphan(client: &impl Client, token: &str) -> Result<(), ClientError> {
     let endpoint = RevokeTokenOrphanRequest::builder()
         .token(token)
@@ -174,7 +162,6 @@ pub async fn revoke_orphan(client: &impl Client, token: &str) -> Result<(), Clie
 /// Revokes the token being sent in the header of this request
 ///
 /// See [RevokeTokenSelfRequest]
-#[instrument(skip(client), err)]
 pub async fn revoke_self(client: &impl Client) -> Result<(), ClientError> {
     let endpoint = RevokeTokenSelfRequest::builder().build().unwrap();
     api::exec_with_empty(client, endpoint).await
@@ -183,7 +170,6 @@ pub async fn revoke_self(client: &impl Client) -> Result<(), ClientError> {
 /// Tidy's up the token backend
 ///
 /// See [TidyRequest]
-#[instrument(skip(client), err)]
 pub async fn tidy(client: &impl Client) -> Result<(), ClientError> {
     let endpoint = TidyRequest::builder().build().unwrap();
     api::exec_with_empty_result(client, endpoint).await
@@ -208,7 +194,6 @@ pub mod role {
     /// Deletes a token role
     ///
     /// See [DeleteTokenRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, role_name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteTokenRoleRequest::builder()
             .role_name(role_name)
@@ -220,7 +205,6 @@ pub mod role {
     /// List token roles
     ///
     /// See [ListTokenRolesRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client) -> Result<ListTokenRolesResponse, ClientError> {
         let endpoint = ListTokenRolesRequest::builder().build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -229,7 +213,6 @@ pub mod role {
     /// Read a token role
     ///
     /// See [ReadTokenRoleRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         role_name: &str,
@@ -244,7 +227,6 @@ pub mod role {
     /// Creates or updates a role
     ///
     /// See [SetTokenRoleRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn set(
         client: &impl Client,
         role_name: &str,

--- a/src/transit.rs
+++ b/src/transit.rs
@@ -13,7 +13,6 @@ pub mod key {
     /// Create a new encryption key.
     ///
     /// See [CreateKeyRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn create(
         client: &impl Client,
         mount: &str,
@@ -33,7 +32,6 @@ pub mod key {
     /// Read encryption key information.
     ///
     /// See [ReadKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -50,7 +48,6 @@ pub mod key {
     /// List key names.
     ///
     /// See [ListKeysRequest]
-    #[instrument(skip(client), err)]
     pub async fn list(client: &impl Client, mount: &str) -> Result<ListKeysResponse, ClientError> {
         let endpoint = ListKeysRequest::builder().mount(mount).build().unwrap();
         api::exec_with_result(client, endpoint).await
@@ -59,7 +56,6 @@ pub mod key {
     /// Update a key's configuration.
     ///
     /// See [UpdateKeyConfigurationRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn update(
         client: &impl Client,
         mount: &str,
@@ -79,7 +75,6 @@ pub mod key {
     /// Delete a named encryption key.
     ///
     /// See [DeleteKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn delete(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = DeleteKeyRequest::builder()
             .mount(mount)
@@ -92,7 +87,6 @@ pub mod key {
     /// Rotate the version of a named key.
     ///
     /// See [RotateKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn rotate(client: &impl Client, mount: &str, name: &str) -> Result<(), ClientError> {
         let endpoint = RotateKeyRequest::builder()
             .mount(mount)
@@ -105,7 +99,6 @@ pub mod key {
     /// Export a named key.
     ///
     /// See [ExportKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn export(
         client: &impl Client,
         mount: &str,
@@ -126,7 +119,6 @@ pub mod key {
     /// Return a plaintext backup of a named key.
     ///
     /// See [BackupKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn backup(
         client: &impl Client,
         mount: &str,
@@ -143,7 +135,6 @@ pub mod key {
     /// Restores the backup of a named key.
     ///
     /// See [RestoreKeyRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn restore(
         client: &impl Client,
         mount: &str,
@@ -163,7 +154,6 @@ pub mod key {
     /// Trim older key versions setting a minimum version for the keyring.
     ///
     /// See [TrimKeyRequest]
-    #[instrument(skip(client), err)]
     pub async fn trim(
         client: &impl Client,
         mount: &str,
@@ -198,7 +188,6 @@ pub mod data {
     /// Encrypt base64-encoded plaintext data using the named key.
     ///
     /// See [EncryptDataRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn encrypt(
         client: &impl Client,
         mount: &str,
@@ -220,7 +209,6 @@ pub mod data {
     /// Decrypt the provided ciphertext using the named key.
     ///
     /// See [DecryptDataRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn decrypt(
         client: &impl Client,
         mount: &str,
@@ -243,7 +231,6 @@ pub mod data {
     /// key.
     ///
     /// See [RewrapDataRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn rewrap(
         client: &impl Client,
         mount: &str,
@@ -265,7 +252,6 @@ pub mod data {
     /// Return the cryptographic signature of the base64-encoded input data.
     ///
     /// See [SignDataRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn sign(
         client: &impl Client,
         mount: &str,
@@ -288,7 +274,6 @@ pub mod data {
     /// input data.
     ///
     /// See [SignDataRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn verify(
         client: &impl Client,
         mount: &str,
@@ -328,7 +313,6 @@ pub mod generate {
     /// key.
     ///
     /// See [GenerateDataKeyRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn data_key(
         client: &impl Client,
         mount: &str,
@@ -350,7 +334,6 @@ pub mod generate {
     /// Generate random bytes.
     ///
     /// See [GenerateRandomBytesRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn random_bytes(
         client: &impl Client,
         mount: &str,
@@ -372,7 +355,6 @@ pub mod generate {
     /// Return the cryptographic hash of the base64-encoded input data.
     ///
     /// See [HashDataRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn hash(
         client: &impl Client,
         mount: &str,
@@ -392,7 +374,6 @@ pub mod generate {
     /// Return the digest of the base64-encoded input data.
     ///
     /// See [GenerateHmacRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn hmac(
         client: &impl Client,
         mount: &str,
@@ -425,7 +406,6 @@ pub mod cache {
     /// Read the transit cache configuration.
     ///
     /// See [ReadTransitCacheConfigurationRequest]
-    #[instrument(skip(client), err)]
     pub async fn read(
         client: &impl Client,
         mount: &str,
@@ -440,7 +420,6 @@ pub mod cache {
     /// Configure the transit engine's cache.
     ///
     /// See [ConfigureCacheRequest]
-    #[instrument(skip(client, opts), err)]
     pub async fn configure(
         client: &impl Client,
         mount: &str,

--- a/vaultrs-login/src/method.rs
+++ b/vaultrs-login/src/method.rs
@@ -135,7 +135,6 @@ pub fn default_mount(method: &Method) -> String {
 }
 
 /// Returns a list of login methods available on the Vault server
-#[instrument(skip(client), err)]
 pub async fn list(client: &impl Client) -> Result<HashMap<String, Method>, ClientError> {
     let mounts = vaultrs::sys::auth::list(client).await?;
     let mut result = HashMap::new();
@@ -146,7 +145,6 @@ pub async fn list(client: &impl Client) -> Result<HashMap<String, Method>, Clien
 }
 
 /// Returns a list of login methods currently supported by this crate
-#[instrument(skip(client), err)]
 pub async fn list_supported(client: &impl Client) -> Result<HashMap<String, Method>, ClientError> {
     let mut mounts = list(client).await?;
     mounts.retain(|_, v| SUPPORTED_METHODS.contains(v));


### PR DESCRIPTION
Attempt to address some of the concerns raised in https://github.com/jmgilman/vaultrs/issues/86

- add the HTTP verb to the log to differentiate which endpoint is actually used
- use structured logging, so it will be easier to process the log afterward. For instance, structured logging allows data  to be a key value inside a json  
- move the span from the top-level function to the inner wrapper, so we don't get to see the parameters. Parameters can contain sensitive information (https://github.com/jmgilman/vaultrs/pull/85) and tends to bloat the logs. Users can still log the parameter if they want by adding a trace themself.
- remove some info traces that were redundant or did not contains useful information

Here there is an example to the new log, which can be useful to compare with the one in https://github.com/jmgilman/vaultrs/pull/85 . Here, `RUST_LOG="info,rustify=off"` is used, as it won't likely to be fixed upstream.
 
Unhappy path: 


```
2024-03-27T08:06:02.413716Z  INFO request{method=GET path=/sys/health}: vaultrs::api: start request
2024-03-27T08:06:02.422478Z ERROR request{method=GET path=/sys/health}: vaultrs::api: error=An error occurred with the request
```

Happy path:

```
2024-03-27T08:06:00.283379Z  INFO request{method=POST path=/sys/init}: vaultrs::api: start request
```

