### PR TITLE
Re-export identity to allow users to use a different version of reqwest

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use crate::api::AuthInfo;
 use crate::api::{token::responses::LookupTokenResponse, EndpointMiddleware};
 use crate::error::ClientError;
 use async_trait::async_trait;
+pub use reqwest::Identity;
 use rustify::clients::reqwest::Client as HTTPClient;
 use std::time::Duration;
 use std::{env, fs};
@@ -160,7 +161,7 @@ pub struct VaultClientSettings {
     #[builder(default = "self.default_ca_certs()")]
     pub ca_certs: Vec<String>,
     #[builder(default = "self.default_identity()")]
-    pub identity: Option<reqwest::Identity>,
+    pub identity: Option<Identity>,
     #[builder(default)]
     pub timeout: Option<Duration>,
     #[builder(setter(into), default = "self.default_token()")]


### PR DESCRIPTION
I was trying to bump reqwest to version 0.12.x in my project.

However, I couldn't because the latest version of vaultrs uses version 0.11.x so I was not able to build an `Identity`:

```
error[E0308]: mismatched types
   |
90 |             identity,
   |             ^^^^^^^^ expected `reqwest::tls::Identity`, found `reqwest::Identity`
   |
   = note: `reqwest::Identity` and `reqwest::tls::Identity` have similar names, but are actually distinct types
note: `reqwest::Identity` is defined in crate `reqwest`
  --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/reqwest-0.12.2/src/tls.rs:77:1
   |
77 | pub struct Identity {
   | ^^^^^^^^^^^^^^^^^^^
note: `reqwest::tls::Identity` is defined in crate `reqwest`
  --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/reqwest-0.11.27/src/tls.rs:75:1
   |
75 | pub struct Identity {
   | ^^^^^^^^^^^^^^^^^^^
   = note: perhaps two different versions of crate `reqwest` are being used?
```

By having vaultrs re-export `Identity`, I can then import `Identity` from `vaultrs::client` and have the correct version.