### PR TITLE
bump reqwest to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ native-tls-vendored = [ "reqwest/native-tls-vendored", "rustify/default" ]
 async-trait = "0.1.68"
 bytes = "1.4.0"
 derive_builder = "0.12.0"
-http = "0.2.9"
-reqwest = { version = "0.11.15", default-features = false }
-rustify = { version = "0.5.3", default-features = false }
+http = "1"
+reqwest = { version = "0.12.2", default-features = false }
+rustify = { version = "0.6.0", default-features = false }
 rustify_derive = "0.5.2"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"


### PR DESCRIPTION
Bump reqwest to 0.12, unlocking the use of hyper 1.0 and rustls 0.22 

~~Waiting on https://github.com/jmgilman/rustify/pull/17~~
