### PR TITLE
fix: pin rustify version to 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytes = "1.4.0"
 derive_builder = "0.12.0"
 http = "0.2.9"
 reqwest = { version = "0.11.15", default-features = false }
-rustify = { version = "0.5.3", default-features = false }
+rustify = { version = "=0.5.3", default-features = false }
 rustify_derive = "0.5.2"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"


### PR DESCRIPTION
Vaultrs is not building due to a mismatched type error, this MR temporarily fixes  #91 untill we bump the reqwest version to match rustify's one.

In [Rustify version 0.5.4](https://github.com/jmgilman/rustify/blob/master/Cargo.toml#L30), the reqwest crate was updated to version 0.12.x. This update is causing conflicts with reqwest version 0.11.x, which we currently use in vaultrs.

This merge request proposes pinning Rustify to version 0.5.3. This action will prevent automatic upgrades to version 0.5.4, where the conflicting change was introduced.

See logs below:

`error[E0053]: method `request` has an incompatible type for trait
   --> src/api.rs:147:14
    |
147 |         req: &mut http::Request<Vec<u8>>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |              |
    |              expected `http::request::Request<Vec<u8>>`, found `http::Request<Vec<u8>>`
    |              help: change the parameter type to match the trait: `&mut http::request::Request<Vec<u8>>`
    |
    = note: expected signature `fn(&EndpointMiddleware, &_, &mut http::request::Request<Vec<u8>>) -> Result<_, _>`
               found signature `fn(&EndpointMiddleware, &_, &mut http::Request<Vec<u8>>) -> Result<_, _>`

error[E0053]: method `response` has an incompatible type for trait
   --> src/api.rs:201:12
    |
201 |         _: &mut http::Response<Vec<u8>>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |            |
    |            expected `http::response::Response<Vec<u8>>`, found `http::Response<Vec<u8>>`
    |            help: change the parameter type to match the trait: `&mut http::response::Response<Vec<u8>>`
    |
    = note: expected signature `fn(&EndpointMiddleware, &_, &mut http::response::Response<Vec<u8>>) -> Result<_, _>`
               found signature `fn(&EndpointMiddleware, &_, &mut http::Response<Vec<u8>>) -> Result<_, _>`

error[E0308]: mismatched types
   --> src/client.rs:134:63
    |
134 |         let http = HTTPClient::new(settings.address.as_str(), http_client);
    |                    ---------------                            ^^^^^^^^^^^ expected `reqwest::async_impl::client::Client`, found `reqwest::Client`
    |                    |
    |                    arguments to this function are incorrect
    |
    = note: `reqwest::Client` and `reqwest::async_impl::client::Client` have similar names, but are actually distinct types
note: `reqwest::Client` is defined in crate `reqwest`
   --> /home/renan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/reqwest-0.11.27/src/async_impl/client.rs:69:1
    |
69  | pub struct Client {
    | ^^^^^^^^^^^^^^^^^
note: `reqwest::async_impl::client::Client` is defined in crate `reqwest`
   --> /home/renan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/reqwest-0.12.4/src/async_impl/client.rs:71:1
    |
71  | pub struct Client {
    | ^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `reqwest` are being used?
note: associated function defined here
   --> /home/renan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustify-0.5.4/src/clients/reqwest.rs:43:12
    |
43  |     pub fn new(base: &str, http: reqwest::Client) -> Self {
`