### PR TITLE
fix: VAULT_SKIP_VERIFY inverted behavior

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -231,7 +231,9 @@ impl VaultClientSettingsBuilder {
     fn default_verify(&self) -> bool {
         info!("Checking TLS verification using $VAULT_SKIP_VERIFY");
         match env::var("VAULT_SKIP_VERIFY") {
-            Ok(value) => !matches!(value.to_lowercase().as_str(), "0" | "f" | "false"),
+            // If VAULT_SKIP_VERIFY is set to '0', 'f' or 'false', verify is enabled
+            // Any other value will skip verification
+            Ok(value) => matches!(value.to_lowercase().as_str(), "0" | "f" | "false"),
             Err(_) => true,
         }
     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -63,7 +63,8 @@ fn test_should_verify_tls() {
     for value in ["", "1", "t", "T", "true", "True", "TRUE"] {
         env::set_var(VAULT_SKIP_VERIFY, value);
         let client = build_client();
-        assert!(client.settings.verify);
+        // Setting truthy value for SKIP_VERIFY should disable verify
+        assert_eq!(client.settings.verify, false);
     }
 }
 
@@ -71,16 +72,18 @@ fn test_should_verify_tls() {
 #[serial_test::serial]
 fn test_should_not_verify_tls() {
     for value in ["0", "f", "F", "false", "False", "FALSE"] {
+        // Setting falsy value for SKIP_VERIFY should enable verify
         env::set_var(VAULT_SKIP_VERIFY, value);
         let client = build_client();
-        assert!(!client.settings.verify);
+        assert_eq!(client.settings.verify, true);
     }
 }
 
 #[test]
 #[serial_test::serial]
 fn test_should_verify_tls_if_variable_is_not_set() {
+    // Not setting SKIP_VERIFY should enable verify
     env::remove_var(VAULT_SKIP_VERIFY);
     let client = build_client();
-    assert!(client.settings.verify);
+    assert_eq!(client.settings.verify, true);
 }


### PR DESCRIPTION
VAULT_SKIP_VERIFY=1 was actually ENABLING verify while VAULT_SKIP_VERIFY=0 was SKIPPING verify. We want the opposite.

I was able to `cargo build` but not `cargo test` in a `nix develop` shell, I had failure:

```sh
$ cargo test
   Compiling vaultrs v0.7.2 (/home/pbeucher/git/vaultrs)
error[E0277]: the trait bound `Vec<std::string::String>: From<&[std::string::String; 2]>` is not satisfied
   --> tests/identity.rs:224:44
    |
224 |     identity::entity::batch_delete(client, &[entity1.id.to_string(), entity2.id.to_string()])
    |     ------------------------------         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&[std::string::String; 2]>` is not implemented for `Vec<std::string::String>`
    |     |
    |     required by a bound introduced by this call
    |
    = note: required for `&[std::string::String; 2]` to implement `Into<Vec<std::string::String>>`
note: required by a bound in `batch_delete`
   --> /home/pbeucher/git/vaultrs/src/identity/entity.rs:77:43
    |
77  | pub async fn batch_delete<T: fmt::Debug + Into<Vec<String>>>(
    |                                           ^^^^^^^^^^^^^^^^^ required by this bound in `batch_delete`
help: consider dereferencing here
    |
224 |     identity::entity::batch_delete(client, *&[entity1.id.to_string(), entity2.id.to_string()])
    |                                            +

For more information about this error, try `rustc --explain E0277`.
error: could not compile `vaultrs` (test "identity") due to previous error
warning: build failed, waiting for other jobs to finish...
[Vaultrs Devshell]$ rustc --version
rustc 1.70.0-nightly (8be3c2bda 2023-03-24)
```

This does not seem related to my local changes, maybe Nix dev shell is broken?

But I hope change is simple enough, if a reviewer or owner can test it on its own :)