### PR TITLE
#93 Add support for asymmetric keys to vault transit engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { version = "0.1.37", features = ["log"] }
 
 [dev-dependencies]
 base64 = "0.21"
+chrono = "0.4.38"
 data-encoding = "2.3.3"
 tokio-test = "0.4.2"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }

--- a/src/api/transit.rs
+++ b/src/api/transit.rs
@@ -26,10 +26,14 @@ pub enum KeyType {
     /// ECDSA using the P-521 elliptic curve (asymmetric)
     EcdsaP521,
     /// RSA with bit size of 2048 (asymmetric)
+    // kebab-case conversion doesn't work for words starting with a digit.
+    #[serde(rename = "rsa-2048")]
     Rsa2048,
     /// RSA with bit size of 3072 (asymmetric)
+    #[serde(rename = "rsa-3072")]
     Rsa3072,
     /// RSA with bit size of 4096 (asymmetric)
+    #[serde(rename = "rsa-4096")]
     Rsa4096,
 }
 

--- a/src/api/transit/responses.rs
+++ b/src/api/transit/responses.rs
@@ -12,7 +12,8 @@ pub struct ReadKeyResponse {
     pub derived: bool,
     pub exportable: bool,
     pub allow_plaintext_backup: bool,
-    pub keys: HashMap<String, u64>,
+    /// If the key is asymmetric, the API returns the public keys
+    pub keys: ReadKeyData,
     pub min_decryption_version: u64,
     pub min_encryption_version: u64,
     pub name: String,
@@ -21,6 +22,23 @@ pub struct ReadKeyResponse {
     pub supports_derivation: bool,
     pub supports_signing: bool,
     pub imported: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ReadKeyData {
+    /// A key ID integer (string) to unix timestamp.
+    Symmetric(HashMap<String, u64>),
+    /// A key ID integer (string) to public key mapping.
+    Asymmetric(HashMap<String, ReadPublicKeyEntry>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ReadPublicKeyEntry {
+    /// An ISO8601 timestamp
+    pub creation_time: String,
+    pub name: String,
+    pub public_key: String,
 }
 
 /// Response from executing

--- a/src/api/transit/responses.rs
+++ b/src/api/transit/responses.rs
@@ -33,7 +33,7 @@ pub enum ReadKeyData {
     Asymmetric(HashMap<String, ReadPublicKeyEntry>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ReadPublicKeyEntry {
     /// An ISO8601 timestamp
     pub creation_time: String,


### PR DESCRIPTION
As described in #93 the current implementation fails to deserialize a read transit engine key response if the key is asymmetric. The asymmetric response differs as it includes the public key inside of the keys field:

```
// vault@926ee8c21172:/$ curl -XGET --insecure --silent -H "X-Vault-Token: $VAULT_TOKEN" $VAULT_ADDR/v1/transit/keys/my-new-key
{
    "request_id": "b59d5612-b16f-8742-641c-32e29943433f",
    "lease_id": "",
    "renewable": false,
    "lease_duration": 0,
    "data": {
        "allow_plaintext_backup": false,
        "auto_rotate_period": 0,
        "deletion_allowed": false,
        "derived": false,
        "exportable": false,
        "imported_key": false,
        "keys": {
            "1": {
                "creation_time": "2024-05-10T13:36:49.809157592Z",
                "name": "rsa-2048",
                "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA01QgwZl/tD7cWZl1NPQ2\nG8+cvI6KkF+wB94xfatdKJ07Ga0bsqYaeE98ZUZU7amRH9Kmdz/4Cu9xXdwlosSS\ntedXfRT8zcWpqEUpV4c4/lT/ox6W67KW2l44liiVt2f9PmviRoYclNWUJa6X+ZCU\n68p/Rd9RSb/xBsywTb8uJN1Q1cZM2JbKhWnaLa7jPsXG9hvnxJ2QFuN3+iZ2OCff\nCjhl0Anumc7lL6wEU/Yd1WuX+5afcHaGttHkWAasrhq3KFHhXlwf4+jrJ5C+aOfb\nevJgGUYjXgf4buV3sPFVmnhvyiyyEV/CysNbXx3KrI/OGgf7HQ+f3+hnpomo8lhd\nwwIDAQAB\n-----END PUBLIC KEY-----\n"
            },
            "2": {
                "creation_time": "2024-05-10T13:36:49.878041842Z",
                "name": "rsa-2048",
                "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7Ttq3kD0Tev7uWnupVGS\neGl4IURKqiUpoPKdevpnYTfuKt/MVP9Ej1Qz7XOP3q6mC3Vb0mSK+6FNjWNakd7D\nQecJwVFuZXp4lF8uzTF5xXFiPiiw5WMS7v7oNmzTE15Msse1yLHcxQGveeRmrl1L\nTYzcLHb705AzgeXoHqLNNWfTC72fqlPhMvOIcWyWOatz/Dp9ukfcR7HAmxhlpluY\n8e+lift8xah4uQFFDuIwXBQ7f5G8+j9RKMyWjA8pv/pY12jDl/vOi6V2b5YJvJie\nVV9gNa1+9JjamG1bsmHYhRIK0rBTewdvD3Tyg+T8Yl5HQNqkIvdwaBZ/RIc+PVeI\ndwIDAQAB\n-----END PUBLIC KEY-----\n"
            },
            "3": {
                "creation_time": "2024-05-10T13:36:49.958724342Z",
                "name": "rsa-2048",
                "public_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu5FQYHEs8U1QsnkTMDrB\n6MfpGK1eVdS84FepYyvpA//suDbJGS9l6XP333wuebwoTL42B5qiZ1tudbIeOWaK\nBDQ5dfjbjRB87k/h4nuQ2DNEUwhgVPjxS3XEocefVWxCfmwQqTjSvhVX2l3DmWiE\n1b/vgikBcYxkqTDTUytuN+IbvZmkFzcM+20UaemRQ5VeNP2MEjZsX4cBATFMkC6k\nYoXb3r+SeKd5JDp/qCSUeabkaxBoV1MprXCy8sEgxSEn/1SGOlVQvB9COQQ/Y/bq\nHQUNGKgrQWGXh4W+Uz4C/GIsKosVuTcGV/o/eONg5uft958NTa1vf93XaKpLOlbw\nOQIDAQAB\n-----END PUBLIC KEY-----\n"
            }
        },
        "latest_version": 3,
        "min_available_version": 0,
        "min_decryption_version": 1,
        "min_encryption_version": 0,
        "name": "my-new-key",
        "supports_decryption": true,
        "supports_derivation": false,
        "supports_encryption": true,
        "supports_signing": true,
        "type": "rsa-2048"
    },
    "wrap_info": null,
    "warnings": null,
    "auth": null
}
```

My implementation follows the normal serde deserialization process using enums to define the two types of key responses. As these fields are `pub`, this will likely be a breaking change for anybody relying on the `ReadKeyResponse.keys` value.