### PR TITLE
Cleanup testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo test
-        run: cargo test --all-targets --all-features --workspace
+        run: cargo test --all-targets --all-features --workspace -- --include-ignored
       # https://github.com/rust-lang/cargo/issues/6669
       - name: cargo test --doc
         run: cargo test --all-features --workspace --doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,20 @@ jobs:
           components: clippy
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
+  doc:
+    # run docs generation on nightly rather than stable. This enables features like
+    # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
+    # API be documented as only available in some specific platforms.
+    runs-on: ubuntu-latest
+    name: nightly / doc
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-docs-rs
+        uses: dtolnay/install@cargo-docs-rs
+      - name: cargo docs-rs
+        run: cargo docs-rs
   test:
     runs-on: ubuntu-latest
     name: stable / test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ repository = "https://github.com/jmgilman/vaultrs"
 keywords = ["Vault", "API", "Client", "Hashicorp"]
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
 members = [ 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ thiserror = "1.0.40"
 url = "2.3.1"
 tracing = { version = "0.1.37", features = ["log"] }
 
+[dev-dependencies]
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread"]}
+

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ vaultrs = { version = "0.7.3", default-features = false, features = [ "native-tl
 
 ## Usage
 
-### Basic
+### Setup the client
 
 The client is used to configure the connection to Vault and is required to be
 passed to all API calls for execution. Behind the scenes it uses an asynchronous
@@ -92,169 +92,7 @@ let client = VaultClient::new(
 ).unwrap();
 ```
 
-### Secrets
-
-#### AWS
-
-The library currently supports all operations available for the
-AWS Secret Engine.
-
-See [tests/aws.rs][4] for more examples.
-
-```rust,ignore
-use vaultrs::sys::mount;
-use vaultrs::aws;
-use vaultrs::api::aws::requests::{SetConfigurationRequest, CreateUpdateRoleRequest, GenerateCredentialsRequest};
-
-// Mount AWS SE
-mount::enable(&client, "aws_test", "aws", None).await?;
-
-// Configure AWS SE
-aws::config::set(&client, "aws_test", "access_key", "secret_key", Some(SetConfigurationRequest::builder()        
-    .max_retries(3)
-    .region("eu-central-1")
-)).await?;
-
-// Create HVault role
-aws::roles::create_update(&client, "aws_test", "my_role", "assumed_role", Some(CreateUpdateRoleRequest::builder()
-        .role_arns( vec!["arn:aws:iam::123456789012:role/test_role".to_string()] )
-)).await?;
-
-// Generate credentials
-let res = aws::roles::credentials(&client, "aws_test", "my_role", Some(GenerateCredentialsRequest::builder()
-    .ttl("3h")
-)).await?;
-
-let creds = res;
-// creds.access_key
-// creds.secret_key
-// creds.security_token
-```
-
-#### Key Value v2
-
-The library currently supports all operations available for version 2 of the
-key/value store.
-
-```rust,ignore
-use serde::{Deserialize, Serialize};
-use vaultrs::kv2;
-
-// Create and read secrets
-#[derive(Debug, Deserialize, Serialize)]
-struct MySecret {
-    key: String,
-    password: String,
-}
-
-let secret = MySecret {
-    key: "super".to_string(),
-    password: "secret".to_string(),
-};
-kv2::set(
-    &client,
-    "secret",
-    "mysecret",
-    &secret,
-).await;
-
-let secret: MySecret = kv2::read(&client, "secret", "mysecret").await.unwrap();
-println!("{}", secret.password); // "secret"
-```
-
-#### Key Value v1
-
-The library currently supports all operations available for version 1 of the
-key/value store.
-
-```rust,ignore
-use vaultrs::kv1;
-use std::collections::HashMap;
-
-let my_secrets = HashMap::from([
-    ("key1".to_string(), "value1".to_string()),
-    ("key2".to_string(), "value2".to_string())
-]);
-
-kv1::set(&client, "secret", "my/secrets", &my_secrets).await.unwrap();
-
-let read_secrets: HashMap<String, String> = kv1::get(&client, "secret", "my/secrets").await.unwrap();
-
-println!("{:}", read_secrets.get("key1").unwrap()); // value1
-
-let list_secret = kv1::list(&client, "secret", "my").await.unwrap();
-
-println!("{:?}", list_secret.data.keys); // [ "secrets" ]
-
-kv1::delete(&client, "secret", "my/secrets").await.unwrap();
-```
-
-### PKI
-
-The library currently supports all operations available for the PKI secrets
-engine.
-
-```rust,ignore
-use vaultrs::api::pki::requests::GenerateCertificateRequest;
-use vaultrs::pki::cert;
-
-// Generate a certificate using the PKI backend
-let cert = cert::generate(
-    &client,
-    "pki",
-    "my_role",
-    Some(GenerateCertificateRequest::builder().common_name("test.com")),
-).await.unwrap();
-println!("{}", cert.certificate) // "{PEM encoded certificate}"
-```
-
-### Transit
-
-The library supports most operations for the
-[Transit](https://developer.hashicorp.com/vault/api-docs/secret/transit) secrets engine,
-other than importing keys or `batch_input` parameters.
-
-```rust,ignore
-use vaultrs::api::transit::requests::CreateKeyRequest;
-use vaultrs::api::transit::KeyType;
-use vaultrs::transit::key;
-
-// Create an encryption key using the /transit backend
-key::create(
-    &client,
-    "transit",
-    "my-transit-key",
-    Some(CreateKeyRequest::builder()
-       .derive(true)
-       .key_type(KeyType::Aes256Gcm96)
-       .auto_rotate_period("30d")),
-).await.unwrap();
-```
-
-### Wrapping
-
-All requests implement the ability to be
-[wrapped](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping). These
-can be passed in your application internally before being unwrapped.
-
-```rust,ignore
-use vaultrs::api::ResponseWrapper;
-use vaultrs::api::sys::requests::ListMountsRequest;
-
-let endpoint = ListMountsRequest::builder().build().unwrap();
-let wrap_resp = endpoint.wrap(&client).await; // Wrapped response
-assert!(wrap_resp.is_ok());
-
-let wrap_resp = wrap_resp.unwrap(); // Unwrap Result<>
-let info = wrap_resp.lookup(&client).await; // Check status of this wrapped response
-assert!(info.is_ok());
-
-let unwrap_resp = wrap_resp.unwrap(&client).await; // Unwrap the response
-assert!(unwrap_resp.is_ok());
-
-let info = wrap_resp.lookup(&client).await; // Error: response already unwrapped
-assert!(info.is_err());
-```
+For more usages, take a look at [the documentation][6]
 
 ## Error Handling and Tracing
 
@@ -272,7 +110,7 @@ See the the [tests][3] directory for tests. Run tests with `cargo test`.
 
 **Note**: All tests rely on bringing up a local Vault development server using
 Docker. In order to run tests Docker must be running locally (Docker Desktop
-works).
+works). The first run will be longer than other because it will fetch images.
 
 ## Contributing
 
@@ -291,5 +129,5 @@ architecture of this library and how to add additional functionality to it.
 [1]: https://developer.hashicorp.com/vault/
 [2]: https://github.com/jmgilman/vaultrs/issues
 [3]: https://github.com/jmgilman/vaultrs/tree/master/tests
-[4]: https://github.com/jmgilman/vaultrs/tree/master/tests/aws.rs
 [5]: https://github.com/jmgilman/vaultrs/tree/master/CONTRIBUTING.md
+[6]: https://docs.rs/vaultrs

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ See the the [tests][3] directory for tests. Run tests with `cargo test`.
 Docker. In order to run tests Docker must be running locally (Docker Desktop
 works). The first run will be longer than other because it will fetch images.
 
+Some long-running tests are ignored by default locally. To run them do:
+
+```sh
+cargo test -- --include-ignored
+```
+
 ## Contributing
 
 Check out the [issues][2] for items needing attention or submit your own and
@@ -128,6 +134,6 @@ architecture of this library and how to add additional functionality to it.
 
 [1]: https://developer.hashicorp.com/vault/
 [2]: https://github.com/jmgilman/vaultrs/issues
-[3]: https://github.com/jmgilman/vaultrs/tree/master/tests
+[3]: https://github.com/jmgilman/vaultrs/tree/master/vaultrs-tests/tests/api_tests
 [5]: https://github.com/jmgilman/vaultrs/tree/master/CONTRIBUTING.md
 [6]: https://docs.rs/vaultrs

--- a/src/api.rs
+++ b/src/api.rs
@@ -28,7 +28,7 @@ use self::sys::responses::WrappingLookupResponse;
 /// details about any contained leases. The actual response content is contained
 /// in the `data` field.
 ///
-/// Most endpoints are configured to pass their responses through [strip] in
+/// Most endpoints are configured to pass their responses through `strip` in
 /// order to strip the result and return the enclosed response. Any warnings
 /// are automatically logged accordingly.
 #[derive(Deserialize, Debug)]

--- a/src/api/sys/requests.rs
+++ b/src/api/sys/requests.rs
@@ -206,7 +206,7 @@ pub struct ReadHealthRequest {}
 /// * Path: /sys/init
 /// * Method: POST
 /// * Response: [StartInitializationResponse]
-/// * Reference: https://developer.hashicorp.com/vault/api-docs/system/init#start-initialization
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/system/init#start-initialization>
 #[derive(Builder, Default, Endpoint)]
 #[endpoint(
     path = "/sys/init",

--- a/src/kv1.rs
+++ b/src/kv1.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 /// Sets the value of the secret at the given path
 ///
 /// A key called ttl will trigger some special behavior. See the [Vault KV secrets engine documentation][<https://developer.hashicorp.com/vault/docs/secrets/kv>] for details.
-/// See [SetSecretRequest][crate::api::kv1::requests::SetSecretRequest]
+/// See [SetSecretRequest]
 pub async fn set<T: Serialize>(
     client: &impl Client,
     mount: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! # vaultrs
 //! An asynchronous Rust client library for the [Hashicorp Vault] API.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,253 @@
-#![doc = include_str!("../README.md")]
+//! # vaultrs
+//! An asynchronous Rust client library for the [Hashicorp Vault] API.
+//!
+//! ## Usages
+//!
+//! ### AWS
+//!
+//! The library currently supports all operations available for the
+//! AWS Secret Engine.
+//!
+//! See [aws tests] for more examples.
+//!
+//! ```no_run
+//! use vaultrs::sys::mount;
+//! use vaultrs::aws;
+//! use vaultrs::api::aws::requests::{SetConfigurationRequest, CreateUpdateRoleRequest, GenerateCredentialsRequest};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//! # let client = VaultClient::new(
+//! #     VaultClientSettingsBuilder::default()
+//! #         .address("https://127.0.0.1:8200")
+//! #         .token("TOKEN")
+//! #         .build()
+//! #         .unwrap()
+//! # ).unwrap();
+//!
+//! // Mount AWS SE
+//! mount::enable(&client, "aws_test", "aws", None).await?;
+//!
+//! // Configure AWS SE
+//! aws::config::set(&client, "aws_test", "access_key", "secret_key", Some(SetConfigurationRequest::builder()        
+//!     .max_retries(3)
+//!     .region("eu-central-1")
+//! )).await?;
+//!
+//! // Create HVault role
+//! aws::roles::create_update(&client, "aws_test", "my_role", "assumed_role", Some(CreateUpdateRoleRequest::builder()
+//!         .role_arns( vec!["arn:aws:iam::123456789012:role/test_role".to_string()] )
+//! )).await?;
+//!
+//! // Generate credentials
+//! let res = aws::roles::credentials(&client, "aws_test", "my_role", Some(GenerateCredentialsRequest::builder()
+//!     .ttl("3h")
+//! )).await?;
+//!
+//! let creds = res;
+//! // creds.access_key
+//! // creds.secret_key
+//! // creds.security_token
+//! #    Ok(())
+//! # }
+//! ```
+//!
+//! ### Key Value v2
+//!
+//! The library currently supports all operations available for version 2 of the
+//! key/value store.
+//!
+//! ```no_run
+//! use serde::{Deserialize, Serialize};
+//! use vaultrs::kv2;
+//!
+//! // Create and read secrets
+//! #[derive(Debug, Deserialize, Serialize)]
+//! struct MySecret {
+//!     key: String,
+//!     password: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//! # let client = VaultClient::new(
+//! #     VaultClientSettingsBuilder::default()
+//! #         .address("https://127.0.0.1:8200")
+//! #         .token("TOKEN")
+//! #         .build()
+//! #         .unwrap()
+//! # ).unwrap();
+//!
+//! let secret = MySecret {
+//!     key: "super".to_string(),
+//!     password: "secret".to_string(),
+//! };
+//! kv2::set(
+//!     &client,
+//!     "secret",
+//!     "mysecret",
+//!     &secret,
+//! ).await;
+//!
+//! let secret: MySecret = kv2::read(&client, "secret", "mysecret").await.unwrap();
+//! println!("{}", secret.password); // "secret"
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Key Value v1
+//!
+//! The library currently supports all operations available for version 1 of the
+//! key/value store.
+//!
+//! ```no_run
+//! use vaultrs::kv1;
+//! use std::collections::HashMap;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//! # let client = VaultClient::new(
+//! #     VaultClientSettingsBuilder::default()
+//! #         .address("https://127.0.0.1:8200")
+//! #         .token("TOKEN")
+//! #         .build()
+//! #         .unwrap()
+//! # ).unwrap();
+//!
+//! let my_secrets = HashMap::from([
+//!     ("key1", "value1"),
+//!     ("key2", "value2")
+//! ]);
+//!
+//! kv1::set(&client, "secret", "my/secrets", &my_secrets).await.unwrap();
+//!
+//! let read_secrets: HashMap<String, String> = kv1::get(&client, "secret", "my/secrets").await.unwrap();
+//!
+//! println!("{:}", read_secrets.get("key1").unwrap()); // value1
+//!
+//! let list_secret = kv1::list(&client, "secret", "my").await.unwrap();
+//!
+//! println!("{:?}", list_secret.data.keys); // [ "secrets" ]
+//!
+//! kv1::delete(&client, "secret", "my/secrets").await.unwrap();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### PKI
+//!
+//! The library currently supports all operations available for the PKI secrets
+//! engine.
+//!
+//! ```no_run
+//! use vaultrs::api::pki::requests::GenerateCertificateRequest;
+//! use vaultrs::pki::cert;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//! # let client = VaultClient::new(
+//! #     VaultClientSettingsBuilder::default()
+//! #         .address("https://127.0.0.1:8200")
+//! #         .token("TOKEN")
+//! #         .build()
+//! #         .unwrap()
+//! # ).unwrap();
+//!
+//! // Generate a certificate using the PKI backend
+//! let cert = cert::generate(
+//!     &client,
+//!     "pki",
+//!     "my_role",
+//!     Some(GenerateCertificateRequest::builder().common_name("test.com")),
+//! ).await?;
+//! println!("{}", cert.certificate); // "{PEM encoded certificate}"
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Transit
+//!
+//! The library supports most operations for the
+//! [Transit](https://developer.hashicorp.com/vault/api-docs/secret/transit) secrets engine,
+//! other than importing keys or `batch_input` parameters.
+//!
+//! ```no_run
+//! use vaultrs::api::transit::requests::CreateKeyRequest;
+//! use vaultrs::api::transit::KeyType;
+//! use vaultrs::transit::key;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//! # let client = VaultClient::new(
+//! #     VaultClientSettingsBuilder::default()
+//! #         .address("https://127.0.0.1:8200")
+//! #         .token("TOKEN")
+//! #         .build()
+//! #         .unwrap()
+//! # ).unwrap();
+//!
+//! // Create an encryption key using the /transit backend
+//! key::create(
+//!     &client,
+//!     "transit",
+//!     "my-transit-key",
+//!     Some(CreateKeyRequest::builder()
+//!        .derived(true)
+//!        .key_type(KeyType::Aes256Gcm96)
+//!        .auto_rotate_period("30d")),
+//! ).await.unwrap();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Wrapping
+//!
+//! All requests implement the ability to be
+//! [wrapped](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping). These
+//! can be passed in your application internally before being unwrapped.
+//!
+//! ```no_run
+//! use vaultrs::api::ResponseWrapper;
+//! use vaultrs::api::sys::requests::ListMountsRequest;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//! # let client = VaultClient::new(
+//! #     VaultClientSettingsBuilder::default()
+//! #         .address("https://127.0.0.1:8200")
+//! #         .token("TOKEN")
+//! #         .build()
+//! #         .unwrap()
+//! # ).unwrap();
+//!
+//!
+//! let endpoint = ListMountsRequest::builder().build().unwrap();
+//! let wrap_resp = endpoint.wrap(&client).await; // Wrapped response
+//! assert!(wrap_resp.is_ok());
+//!
+//! let wrap_resp = wrap_resp.unwrap(); // Unwrap Result<>
+//! let info = wrap_resp.lookup(&client).await; // Check status of this wrapped response
+//! assert!(info.is_ok());
+//!
+//! let unwrap_resp = wrap_resp.unwrap(&client).await; // Unwrap the response
+//! assert!(unwrap_resp.is_ok());
+//!
+//! let info = wrap_resp.lookup(&client).await; // Error: response already unwrapped
+//! assert!(info.is_err());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//!
+//! [Hashicorp Vault]: https://developer.hashicorp.com/vault
+//! [aws tests]: https://github.com/jmgilman/vaultrs/blob/master/vaultrs-tests/tests/api_tests/aws.rs
+//!
 
 #[macro_use]
 extern crate derive_builder;

--- a/vaultrs-login/src/lib.rs
+++ b/vaultrs-login/src/lib.rs
@@ -1,6 +1,6 @@
 //! # vaultrs-login
 //!
-//! > Adds login support for Vault clients from [vaultrs][1].
+//! > Adds login support for Vault clients from [vaultrs].
 //!
 //! ## Installation
 //!
@@ -36,13 +36,8 @@
 //! # })
 //! ```
 //!
-//! ## Testing
-//!
-//! Run tests with cargo:
-//!
-//! ```ignore
-//! cargo test
-//! ```
+//! [vaultrs]: https://docs.rs/vaultrs/latest/vaultrs/
+
 #[macro_use]
 extern crate tracing;
 
@@ -85,7 +80,7 @@ pub trait LoginClient: Client + Sized {
     /// Performs a login using the given method and sets the resulting token to
     /// this client.
     #[instrument(skip(self, method), err)]
-    /// Workaround until <https://github.com/tokio-rs/tracing/issues/2876 is fixed>
+    /// Workaround until <https://github.com/tokio-rs/tracing/issues/2876> is fixed
     #[allow(clippy::blocks_in_conditions)]
     async fn login<M: 'static + LoginMethod>(
         &mut self,
@@ -101,7 +96,7 @@ pub trait LoginClient: Client + Sized {
     /// callback which must be passed back to the client to finish the login
     /// flow.
     #[instrument(skip(self, method), err)]
-    /// Workaround until <https://github.com/tokio-rs/tracing/issues/2876 is fixed>
+    /// Workaround until <https://github.com/tokio-rs/tracing/issues/2876> is fixed
     #[allow(clippy::blocks_in_conditions)]
     async fn login_multi<M: 'static + MultiLoginMethod>(
         &self,
@@ -114,7 +109,7 @@ pub trait LoginClient: Client + Sized {
     /// Performs the second step of a multi-step login and sets the resulting
     /// token to this client.
     #[instrument(skip(self, callback), err)]
-    /// Workaround until <https://github.com/tokio-rs/tracing/issues/2876 is fixed>
+    /// Workaround until <https://github.com/tokio-rs/tracing/issues/2876> is fixed
     #[allow(clippy::blocks_in_conditions)]
     async fn login_multi_callback<C: 'static + MultiLoginCallback>(
         &mut self,

--- a/vaultrs-tests/tests/api_tests/approle.rs
+++ b/vaultrs-tests/tests/api_tests/approle.rs
@@ -35,29 +35,29 @@ async fn test() {
 pub async fn test_login(client: &impl Client, endpoint: &AppRoleEndpoint) {
     use vaultrs::auth::approle::role;
 
-    let role_id_resp =
-        role::read_id(client, endpoint.path.as_str(), endpoint.role_name.as_str()).await;
-    assert!(role_id_resp.is_ok());
-    let role_id = role_id_resp.unwrap().role_id;
+    let role_id = role::read_id(client, endpoint.path.as_str(), endpoint.role_name.as_str())
+        .await
+        .unwrap()
+        .role_id;
 
-    let secret_id_resp = role::secret::generate(
+    let secret_id = role::secret::generate(
         client,
         endpoint.path.as_str(),
         endpoint.role_name.as_str(),
         None,
     )
-    .await;
-    assert!(secret_id_resp.is_ok());
-    let secret_id = secret_id_resp.unwrap().secret_id;
+    .await
+    .unwrap()
+    .secret_id;
 
-    let resp = approle::login(
+    approle::login(
         client,
         endpoint.path.as_str(),
         role_id.as_str(),
         secret_id.as_str(),
     )
-    .await;
-    assert!(resp.is_ok());
+    .await
+    .unwrap();
 }
 
 mod role {
@@ -65,45 +65,47 @@ mod role {
     use vaultrs::{api::auth::approle::requests::SetAppRoleRequest, auth::approle::role};
 
     pub async fn test_delete(client: &impl Client, endpoint: &AppRoleEndpoint) {
-        let res = role::delete(client, endpoint.path.as_str(), endpoint.role_name.as_str()).await;
-        assert!(res.is_ok());
+        role::delete(client, endpoint.path.as_str(), endpoint.role_name.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &AppRoleEndpoint) {
-        let res = role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        role::list(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &AppRoleEndpoint) {
-        let res = role::read(client, endpoint.path.as_str(), endpoint.role_name.as_str()).await;
-        assert!(res.is_ok());
+        role::read(client, endpoint.path.as_str(), endpoint.role_name.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &AppRoleEndpoint) {
-        let res = role::set(
+        role::set(
             client,
             endpoint.path.as_str(),
             endpoint.role_name.as_str(),
             Some(&mut SetAppRoleRequest::builder().token_ttl("10m")),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_read_id(client: &impl Client, endpoint: &AppRoleEndpoint) {
-        let res = role::read_id(client, endpoint.path.as_str(), endpoint.role_name.as_str()).await;
-        assert!(res.is_ok());
+        role::read_id(client, endpoint.path.as_str(), endpoint.role_name.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_update_id(client: &impl Client, endpoint: &AppRoleEndpoint) {
-        let res = role::update_id(
+        role::update_id(
             client,
             endpoint.path.as_str(),
             endpoint.role_name.as_str(),
             "test",
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub mod secret {
@@ -114,26 +116,26 @@ mod role {
         };
 
         pub async fn test_custom(client: &impl Client, endpoint: &AppRoleEndpoint) {
-            let res = secret::custom(
+            secret::custom(
                 client,
                 endpoint.path.as_str(),
                 endpoint.role_name.as_str(),
                 "test",
                 None,
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
 
         pub async fn test_delete(client: &impl Client, endpoint: &AppRoleEndpoint, id: &str) {
-            let res = secret::delete(
+            secret::delete(
                 client,
                 endpoint.path.as_str(),
                 endpoint.role_name.as_str(),
                 id,
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
 
         pub async fn test_delete_accessor(
@@ -141,21 +143,21 @@ mod role {
             endpoint: &AppRoleEndpoint,
             accessor: &str,
         ) {
-            let res = secret::delete_accessor(
+            secret::delete_accessor(
                 client,
                 endpoint.path.as_str(),
                 endpoint.role_name.as_str(),
                 accessor,
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
 
         pub async fn test_generate(
             client: &impl Client,
             endpoint: &AppRoleEndpoint,
         ) -> (String, String) {
-            let res = secret::generate(
+            let id = secret::generate(
                 client,
                 endpoint.path.as_str(),
                 endpoint.role_name.as_str(),
@@ -164,28 +166,27 @@ mod role {
                         .metadata("{ \"tag1\": \"production\" }"),
                 ),
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
 
-            let id = res.unwrap();
             (id.secret_id, id.secret_id_accessor)
         }
 
         pub async fn test_list(client: &impl Client, endpoint: &AppRoleEndpoint) {
-            let res =
-                secret::list(client, endpoint.path.as_str(), endpoint.role_name.as_str()).await;
-            assert!(res.is_ok());
+            secret::list(client, endpoint.path.as_str(), endpoint.role_name.as_str())
+                .await
+                .unwrap();
         }
 
         pub async fn test_read(client: &impl Client, endpoint: &AppRoleEndpoint, id: &str) {
-            let res = secret::read(
+            secret::read(
                 client,
                 endpoint.path.as_str(),
                 endpoint.role_name.as_str(),
                 id,
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
 
         pub async fn test_read_accessor(
@@ -193,14 +194,14 @@ mod role {
             endpoint: &AppRoleEndpoint,
             accessor: &str,
         ) {
-            let res = secret::read_accessor(
+            secret::read_accessor(
                 client,
                 endpoint.path.as_str(),
                 endpoint.role_name.as_str(),
                 accessor,
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
     }
 }

--- a/vaultrs-tests/tests/api_tests/aws.rs
+++ b/vaultrs-tests/tests/api_tests/aws.rs
@@ -5,6 +5,7 @@ use vaultrs::error::ClientError;
 use vaultrs::sys::{auth, mount};
 
 #[tokio::test]
+#[ignore]
 async fn test_auth() {
     let test = Test::builder().with_localstack(["iam", "sts"]).await;
     let client = test.client();
@@ -55,6 +56,7 @@ async fn test_auth() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_secret_engine() {
     let test = Test::builder().with_localstack(["iam", "sts"]).await;
 

--- a/vaultrs-tests/tests/api_tests/aws.rs
+++ b/vaultrs-tests/tests/api_tests/aws.rs
@@ -137,14 +137,16 @@ mod config {
         }
 
         pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::client::read(client, &endpoint.path).await;
-            assert!(res.is_ok());
-            assert_eq!(res.unwrap().access_key, Some("test".to_string()));
+            let config = aws::config::client::read(client, &endpoint.path)
+                .await
+                .unwrap();
+            assert_eq!(config.access_key, Some("test".to_string()));
         }
 
         pub async fn test_delete(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::client::delete(client, &endpoint.path).await;
-            assert!(res.is_ok());
+            aws::config::client::delete(client, &endpoint.path)
+                .await
+                .unwrap();
         }
     }
 
@@ -154,7 +156,7 @@ mod config {
         use super::super::{AwsAuthEndpoint, Client};
 
         pub async fn test_set(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::identity::set(
+            aws::config::identity::set(
                 client,
                 &endpoint.path,
                 Some(
@@ -163,17 +165,17 @@ mod config {
                         .ec2_alias("instance_id"),
                 ),
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
 
         pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::identity::read(client, &endpoint.path).await;
-            assert!(res.is_ok());
+            let identity = aws::config::identity::read(client, &endpoint.path)
+                .await
+                .unwrap();
 
-            let res = res.unwrap();
-            assert_eq!(res.iam_alias, Some("unique_id".to_string()));
-            assert_eq!(res.ec2_alias, Some("instance_id".to_string()));
+            assert_eq!(identity.iam_alias, Some("unique_id".to_string()));
+            assert_eq!(identity.ec2_alias, Some("instance_id".to_string()));
         }
     }
 
@@ -187,32 +189,35 @@ mod config {
         const CERT: &str = include_str!("../files/aws.crt");
 
         pub async fn test_create(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::certificate::create(
+            aws::config::certificate::create(
                 client,
                 &endpoint.path,
                 CERT_NAME,
                 &general_purpose::STANDARD.encode(CERT),
                 None,
             )
-            .await;
-            assert!(res.is_ok());
+            .await
+            .unwrap();
         }
 
         pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::certificate::read(client, &endpoint.path, CERT_NAME).await;
-            assert!(res.is_ok());
-            assert_eq!(res.unwrap().aws_public_cert, CERT)
+            let certificate = aws::config::certificate::read(client, &endpoint.path, CERT_NAME)
+                .await
+                .unwrap();
+            assert_eq!(certificate.aws_public_cert, CERT)
         }
 
         pub async fn test_delete(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::certificate::delete(client, &endpoint.path, CERT_NAME).await;
-            assert!(res.is_ok())
+            aws::config::certificate::delete(client, &endpoint.path, CERT_NAME)
+                .await
+                .unwrap();
         }
 
         pub async fn test_list(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::certificate::list(client, &endpoint.path).await;
-            assert!(res.is_ok());
-            assert_eq!(res.unwrap().keys, vec![CERT_NAME])
+            let certificate = aws::config::certificate::list(client, &endpoint.path)
+                .await
+                .unwrap();
+            assert_eq!(certificate.keys, vec![CERT_NAME])
         }
     }
 
@@ -225,27 +230,29 @@ mod config {
         const ROLE_NAME: &str = "SomeRole";
 
         pub async fn test_create(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res =
-                aws::config::sts::create(client, &endpoint.path, SATELLITE_ACCOUNT_ID, ROLE_NAME)
-                    .await;
-            assert!(res.is_ok())
+            aws::config::sts::create(client, &endpoint.path, SATELLITE_ACCOUNT_ID, ROLE_NAME)
+                .await
+                .unwrap();
         }
 
         pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::sts::read(client, &endpoint.path, SATELLITE_ACCOUNT_ID).await;
-            assert!(res.is_ok());
-            assert!(res.unwrap().sts_role.ends_with(ROLE_NAME));
+            let sts = aws::config::sts::read(client, &endpoint.path, SATELLITE_ACCOUNT_ID)
+                .await
+                .unwrap();
+            assert!(sts.sts_role.ends_with(ROLE_NAME));
         }
 
         pub async fn test_list(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::sts::list(client, &endpoint.path).await;
-            assert!(res.is_ok());
-            assert_eq!(res.unwrap().keys, [SATELLITE_ACCOUNT_ID]);
+            let sts = aws::config::sts::list(client, &endpoint.path)
+                .await
+                .unwrap();
+            assert_eq!(sts.keys, [SATELLITE_ACCOUNT_ID]);
         }
 
         pub async fn test_delete(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-            let res = aws::config::sts::delete(client, &endpoint.path, SATELLITE_ACCOUNT_ID).await;
-            assert!(res.is_ok())
+            aws::config::sts::delete(client, &endpoint.path, SATELLITE_ACCOUNT_ID)
+                .await
+                .unwrap();
         }
     }
 
@@ -259,7 +266,7 @@ mod config {
             use super::super::super::{AwsAuthEndpoint, Client};
 
             pub async fn test_set(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-                let res = aws::config::tidy::identity_access_list::set(
+                aws::config::tidy::identity_access_list::set(
                     client,
                     &endpoint.path,
                     Some(
@@ -268,25 +275,21 @@ mod config {
                             .disable_periodic_tidy(true),
                     ),
                 )
-                .await;
-
-                assert!(res.is_ok())
+                .await
+                .unwrap();
             }
             pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-                let res =
-                    aws::config::tidy::identity_access_list::read(client, &endpoint.path).await;
+                let iacl = aws::config::tidy::identity_access_list::read(client, &endpoint.path)
+                    .await
+                    .unwrap();
 
-                assert!(res.is_ok());
-
-                let res = res.unwrap();
-                assert_eq!(res.safety_buffer, 86400);
-                assert!(res.disable_periodic_tidy);
+                assert_eq!(iacl.safety_buffer, 86400);
+                assert!(iacl.disable_periodic_tidy);
             }
             pub async fn test_delete(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-                let res =
-                    aws::config::tidy::identity_access_list::read(client, &endpoint.path).await;
-
-                assert!(res.is_ok());
+                aws::config::tidy::identity_access_list::read(client, &endpoint.path)
+                    .await
+                    .unwrap();
             }
         }
 
@@ -298,7 +301,7 @@ mod config {
             use super::super::super::{AwsAuthEndpoint, Client};
 
             pub async fn test_set(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-                let res = aws::config::tidy::role_tag_deny_list::set(
+                aws::config::tidy::role_tag_deny_list::set(
                     client,
                     &endpoint.path,
                     Some(
@@ -306,23 +309,23 @@ mod config {
                             .safety_buffer("24h"),
                     ),
                 )
-                .await;
-
-                assert!(res.is_ok())
+                .await
+                .unwrap();
             }
 
             pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-                let res = aws::config::tidy::role_tag_deny_list::read(client, &endpoint.path).await;
-                assert!(res.is_ok());
-
-                let res = res.unwrap();
-                assert_eq!(res.safety_buffer, 86400);
-                assert!(!res.disable_periodic_tidy);
+                let denied_tags =
+                    aws::config::tidy::role_tag_deny_list::read(client, &endpoint.path)
+                        .await
+                        .unwrap();
+                assert_eq!(denied_tags.safety_buffer, 86400);
+                assert!(!denied_tags.disable_periodic_tidy);
             }
 
             pub async fn test_delete(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-                let res = aws::config::tidy::role_tag_deny_list::read(client, &endpoint.path).await;
-                assert!(res.is_ok());
+                aws::config::tidy::role_tag_deny_list::read(client, &endpoint.path)
+                    .await
+                    .unwrap();
             }
         }
     }
@@ -343,7 +346,7 @@ mod role {
     const ROLE_NAME_EC2: &str = "test_role_ec2";
 
     pub async fn test_create_iam(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::role::create(
+        aws::role::create(
             client,
             &endpoint.path,
             ROLE_NAME_IAM,
@@ -354,13 +357,12 @@ mod role {
                     .resolve_aws_unique_ids(false),
             ),
         )
-        .await;
-
-        assert!(res.is_ok())
+        .await
+        .unwrap();
     }
 
     pub async fn test_create_ec2(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::role::create(
+        aws::role::create(
             client,
             &endpoint.path,
             ROLE_NAME_EC2,
@@ -371,35 +373,35 @@ mod role {
                     .bound_ec2_instance_id(["i-1234567890abcdef0".to_string()]),
             ),
         )
-        .await;
-
-        assert!(res.is_ok())
+        .await
+        .unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::role::read(client, &endpoint.path, ROLE_NAME_IAM).await;
-        assert!(res.is_ok());
+        let role = aws::role::read(client, &endpoint.path, ROLE_NAME_IAM)
+            .await
+            .unwrap();
         assert_eq!(
-            res.unwrap().bound_iam_principal_arn.unwrap_or_default(),
+            role.bound_iam_principal_arn.unwrap_or_default(),
             ["000000000001"]
         );
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::role::list(client, &endpoint.path).await;
-        assert!(res.is_ok());
+        let roles = aws::role::list(client, &endpoint.path).await.unwrap();
 
-        let res = res.unwrap();
-        assert!(res.keys.contains(&ROLE_NAME_IAM.to_string()));
-        assert!(res.keys.contains(&ROLE_NAME_EC2.to_string()));
+        assert!(roles.keys.contains(&ROLE_NAME_IAM.to_string()));
+        assert!(roles.keys.contains(&ROLE_NAME_EC2.to_string()));
     }
 
     pub async fn test_delete(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::role::delete(client, &endpoint.path, ROLE_NAME_IAM).await;
-        assert!(res.is_ok());
+        aws::role::delete(client, &endpoint.path, ROLE_NAME_IAM)
+            .await
+            .unwrap();
 
-        let res = aws::role::delete(client, &endpoint.path, ROLE_NAME_EC2).await;
-        assert!(res.is_ok());
+        aws::role::delete(client, &endpoint.path, ROLE_NAME_EC2)
+            .await
+            .unwrap();
     }
 
     pub async fn test_create_tag(
@@ -407,17 +409,14 @@ mod role {
         endpoint: &AwsAuthEndpoint,
     ) -> CreateRoleTagResponse {
         // role_tag is only used with ec2 auth method
-        let res = aws::role::create_tag(
+        aws::role::create_tag(
             client,
             &endpoint.path,
             ROLE_NAME_EC2,
             Some(&mut CreateRoleTagRequest::builder().max_ttl("48h")),
         )
-        .await;
-
-        assert!(res.is_ok());
-
-        res.unwrap()
+        .await
+        .unwrap()
     }
 }
 
@@ -437,14 +436,13 @@ mod identity_access_list {
     }
 
     pub async fn test_tidy(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::identity_access_list::tidy(
+        aws::identity_access_list::tidy(
             client,
             &endpoint.path,
             Some(&mut TidyIdentityAccessListEntriesRequest::builder().safety_buffer("12h")),
         )
-        .await;
-
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -461,10 +459,9 @@ mod role_tag_deny_list {
         endpoint: &AwsAuthEndpoint,
         role_tag: &CreateRoleTagResponse,
     ) {
-        let res =
-            aws::role_tag_deny_list::create(client, &endpoint.path, &role_tag.tag_value).await;
-
-        assert!(res.is_ok());
+        aws::role_tag_deny_list::create(client, &endpoint.path, &role_tag.tag_value)
+            .await
+            .unwrap();
     }
 
     pub async fn test_read(
@@ -472,8 +469,9 @@ mod role_tag_deny_list {
         endpoint: &AwsAuthEndpoint,
         role_tag: &CreateRoleTagResponse,
     ) {
-        let res = aws::role_tag_deny_list::read(client, &endpoint.path, &role_tag.tag_value).await;
-        assert!(res.is_ok());
+        aws::role_tag_deny_list::read(client, &endpoint.path, &role_tag.tag_value)
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(
@@ -481,9 +479,10 @@ mod role_tag_deny_list {
         endpoint: &AwsAuthEndpoint,
         role_tag: &CreateRoleTagResponse,
     ) {
-        let res = aws::role_tag_deny_list::list(client, &endpoint.path).await;
-        assert!(res.is_ok());
-        assert!(res.unwrap().keys.contains(&role_tag.tag_value));
+        let denied_tags = aws::role_tag_deny_list::list(client, &endpoint.path)
+            .await
+            .unwrap();
+        assert!(denied_tags.keys.contains(&role_tag.tag_value));
     }
 
     pub async fn test_delete(
@@ -491,19 +490,19 @@ mod role_tag_deny_list {
         endpoint: &AwsAuthEndpoint,
         role_tag: &CreateRoleTagResponse,
     ) {
-        let res =
-            aws::role_tag_deny_list::delete(client, &endpoint.path, &role_tag.tag_value).await;
-        assert!(res.is_ok());
+        aws::role_tag_deny_list::delete(client, &endpoint.path, &role_tag.tag_value)
+            .await
+            .unwrap();
     }
 
     pub async fn test_tidy(client: &impl Client, endpoint: &AwsAuthEndpoint) {
-        let res = aws::role_tag_deny_list::tidy(
+        aws::role_tag_deny_list::tidy(
             client,
             &endpoint.path,
             Some(&mut TidyDenyListTagsRequest::builder().safety_buffer("8h")),
         )
-        .await;
-        assert!(res.is_ok())
+        .await
+        .unwrap();
     }
 }
 
@@ -519,7 +518,7 @@ pub mod secretengine {
             client: &impl Client,
             endpoint: &AwsSecretEngineEndpoint,
         ) {
-            let res = aws::config::set(
+            aws::config::set(
                 client,
                 &endpoint.path,
                 "test",
@@ -532,20 +531,16 @@ pub mod secretengine {
                         .iam_endpoint(localstack_url),
                 ),
             )
-            .await;
-
-            assert!(res.is_ok())
+            .await
+            .unwrap();
         }
 
         pub async fn test_get(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::config::get(client, &endpoint.path).await;
+            let config = aws::config::get(client, &endpoint.path).await.unwrap();
 
-            assert!(res.is_ok());
-
-            let data = res.unwrap();
-            assert!(data.access_key == "test");
-            assert!(data.max_retries == 3);
-            assert!(data.region == "eu-central-1");
+            assert!(config.access_key == "test");
+            assert!(config.max_retries == 3);
+            assert!(config.region == "eu-central-1");
         }
 
         // Doesn't work with Localstack, probably because of limitation with IAM APIs implementation
@@ -559,21 +554,19 @@ pub mod secretengine {
         }
 
         pub async fn test_set_lease(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::config::set_lease(client, &endpoint.path, "1h", "6h").await;
-
-            assert!(res.is_ok());
+            aws::config::set_lease(client, &endpoint.path, "1h", "6h")
+                .await
+                .unwrap();
         }
 
         pub async fn test_read_lease(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::config::read_lease(client, &endpoint.path).await;
-
-            assert!(res.is_ok());
-
-            let data = res.unwrap();
+            let lease = aws::config::read_lease(client, &endpoint.path)
+                .await
+                .unwrap();
 
             // response looks like "1h0m0s"
-            assert!(data.lease.starts_with("1h"));
-            assert!(data.lease_max.starts_with("6h"));
+            assert!(lease.lease.starts_with("1h"));
+            assert!(lease.lease_max.starts_with("6h"));
         }
     }
 
@@ -591,40 +584,31 @@ pub mod secretengine {
         pub const TEST_ARN: &str = "arn:aws:iam::123456789012:role/test_role";
 
         pub async fn test_create_update(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::roles::create_update(
+            aws::roles::create_update(
                 client,
                 &endpoint.path,
                 TEST_ROLE,
                 "assumed_role",
                 Some(CreateUpdateRoleRequest::builder().role_arns(vec![TEST_ARN.to_string()])),
             )
-            .await;
-
-            assert!(res.is_ok())
+            .await
+            .unwrap();
         }
 
         pub async fn test_read(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::roles::read(client, &endpoint.path, TEST_ROLE).await;
+            let data = aws::roles::read(client, &endpoint.path, TEST_ROLE)
+                .await
+                .unwrap();
 
-            assert!(res.is_ok());
-
-            let data = res.unwrap();
             let roles = data.role_arns.unwrap();
 
             assert!(data.credential_type == "assumed_role");
-            assert!(roles[0] == TEST_ARN);
-            assert!(roles.len() == 1);
+            assert_eq!(roles, [TEST_ARN]);
         }
 
         pub async fn test_list(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::roles::list(client, &endpoint.path).await;
-
-            assert!(res.is_ok());
-
-            let data = res.unwrap();
-            dbg!(&data);
-            assert!(data.keys[0] == TEST_ROLE);
-            assert!(data.keys.len() == 1);
+            let roles = aws::roles::list(client, &endpoint.path).await.unwrap();
+            assert_eq!(roles.keys, [TEST_ROLE]);
         }
 
         pub async fn test_credentials(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
@@ -655,26 +639,24 @@ pub mod secretengine {
             client: &impl Client,
             endpoint: &AwsSecretEngineEndpoint,
         ) {
-            let res = aws::roles::credentials_sts(
+            let roles = aws::roles::credentials_sts(
                 client,
                 &endpoint.path,
                 TEST_ROLE,
                 Some(GenerateCredentialsStsRequest::builder().ttl("3h")),
             )
-            .await;
+            .await
+            .unwrap();
 
-            assert!(res.is_ok());
-
-            let data = res.unwrap();
-            assert!(data.access_key.starts_with("LSIA"));
-            assert!(!data.secret_key.is_empty());
-            assert!(!data.security_token.unwrap().is_empty());
+            assert!(roles.access_key.starts_with("LSIA"));
+            assert!(!roles.secret_key.is_empty());
+            assert!(!roles.security_token.unwrap().is_empty());
         }
 
         pub async fn test_delete(client: &impl Client, endpoint: &AwsSecretEngineEndpoint) {
-            let res = aws::roles::delete(client, &endpoint.path, TEST_ROLE).await;
-
-            assert!(res.is_ok());
+            aws::roles::delete(client, &endpoint.path, TEST_ROLE)
+                .await
+                .unwrap();
 
             // check deletion actually worked, list should be empty (Vault returns 404)
             let res_after = aws::roles::list(client, &endpoint.path).await;

--- a/vaultrs-tests/tests/api_tests/cert.rs
+++ b/vaultrs-tests/tests/api_tests/cert.rs
@@ -63,19 +63,21 @@ pub mod ca_cert_role {
     use super::CertEndpoint;
 
     pub async fn test_delete(client: &impl Client, endpoint: &CertEndpoint) {
-        let res =
-            ca_cert_role::delete(client, endpoint.path.as_str(), endpoint.name.as_str()).await;
-        assert!(res.is_ok());
+        ca_cert_role::delete(client, endpoint.path.as_str(), endpoint.name.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &CertEndpoint) {
-        let res = ca_cert_role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        ca_cert_role::list(client, endpoint.path.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &CertEndpoint) {
-        let res = ca_cert_role::read(client, endpoint.path.as_str(), endpoint.name.as_str()).await;
-        assert!(res.is_ok());
+        ca_cert_role::read(client, endpoint.path.as_str(), endpoint.name.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &CertEndpoint, ca_cert: &Path) {

--- a/vaultrs-tests/tests/api_tests/database.rs
+++ b/vaultrs-tests/tests/api_tests/database.rs
@@ -1,7 +1,6 @@
 use tracing::debug;
 use vaultrs::api::database::requests::PostgreSQLConnectionRequest;
 use vaultrs::client::Client;
-use vaultrs::error::ClientError;
 use vaultrs::sys::mount;
 
 use crate::common::{Test, POSTGRES_PASSWORD, POSTGRES_USER};
@@ -11,7 +10,7 @@ async fn test() {
     let test = Test::builder().with_postgres().await;
     let client = test.client();
     let db_url = test.postgres_url().unwrap();
-    let endpoint = setup(db_url, client).await.unwrap();
+    let endpoint = setup(db_url, client).await;
 
     // Test reset/rotate
     connection::test_reset(client, &endpoint).await;
@@ -43,21 +42,23 @@ mod connection {
     use vaultrs::database::connection;
 
     pub async fn test_delete(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res =
-            connection::delete(client, endpoint.path.as_str(), endpoint.connection.as_str()).await;
-        assert!(res.is_ok());
+        connection::delete(client, endpoint.path.as_str(), endpoint.connection.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = connection::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
-        assert!(!res.unwrap().keys.is_empty());
+        assert!(!connection::list(client, endpoint.path.as_str())
+            .await
+            .unwrap()
+            .keys
+            .is_empty());
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res =
-            connection::read(client, endpoint.path.as_str(), endpoint.connection.as_str()).await;
-        assert!(res.is_ok());
+        connection::read(client, endpoint.path.as_str(), endpoint.connection.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_reset(client: &impl Client, endpoint: &DatabaseEndpoint) {
@@ -68,9 +69,9 @@ mod connection {
     }
 
     pub async fn test_rotate(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res =
-            connection::rotate(client, endpoint.path.as_str(), endpoint.connection.as_str()).await;
-        assert!(res.is_ok());
+        connection::rotate(client, endpoint.path.as_str(), endpoint.connection.as_str())
+            .await
+            .unwrap();
     }
 }
 
@@ -79,29 +80,34 @@ mod role {
     use vaultrs::{api::database::requests::SetRoleRequest, database::role};
 
     pub async fn test_creds(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = role::creds(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::creds(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_delete(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = role::delete(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::delete(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
-        assert!(!res.unwrap().keys.is_empty());
+        assert!(!role::list(client, endpoint.path.as_str())
+            .await
+            .unwrap()
+            .keys
+            .is_empty());
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = role::read(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::read(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &DatabaseEndpoint) {
         let sql = r#"CREATE ROLE "{{name}}" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';"#;
-        let res = role::set(
+        role::set(
             client,
             endpoint.path.as_str(),
             endpoint.role.as_str(),
@@ -111,8 +117,8 @@ mod role {
                     .creation_statements(vec![sql.into()]),
             ),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -121,43 +127,45 @@ mod static_role {
     use vaultrs::{api::database::requests::SetStaticRoleRequest, database::static_role};
 
     pub async fn test_creds(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = static_role::creds(
+        static_role::creds(
             client,
             endpoint.path.as_str(),
             endpoint.static_role.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_delete(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = static_role::delete(
+        static_role::delete(
             client,
             endpoint.path.as_str(),
             endpoint.static_role.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = static_role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
-        assert!(!res.unwrap().keys.is_empty());
+        assert!(!static_role::list(client, endpoint.path.as_str())
+            .await
+            .unwrap()
+            .keys
+            .is_empty());
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = static_role::read(
+        static_role::read(
             client,
             endpoint.path.as_str(),
             endpoint.static_role.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = static_role::set(
+        static_role::set(
             client,
             endpoint.path.as_str(),
             endpoint.static_role.as_str(),
@@ -168,18 +176,18 @@ mod static_role {
                     .rotation_period("10m"),
             ),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_rotate(client: &impl Client, endpoint: &DatabaseEndpoint) {
-        let res = static_role::rotate(
+        static_role::rotate(
             client,
             endpoint.path.as_str(),
             endpoint.static_role.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -192,7 +200,7 @@ pub struct DatabaseEndpoint {
     pub username: String,
 }
 
-async fn setup(db_url: &str, client: &impl Client) -> Result<DatabaseEndpoint, ClientError> {
+async fn setup(db_url: &str, client: &impl Client) -> DatabaseEndpoint {
     debug!("setting up database secret engine");
 
     let path = "db_test";
@@ -207,7 +215,6 @@ async fn setup(db_url: &str, client: &impl Client) -> Result<DatabaseEndpoint, C
         "postgresql://{{{{username}}}}:{{{{password}}}}@{}/postgres?sslmode=disable",
         db_url
     );
-    dbg!(&url);
     vaultrs::database::connection::postgres(
         client,
         path,
@@ -222,13 +229,14 @@ async fn setup(db_url: &str, client: &impl Client) -> Result<DatabaseEndpoint, C
                 .allowed_roles(vec!["*".into()]),
         ),
     )
-    .await?;
+    .await
+    .unwrap();
 
-    Ok(DatabaseEndpoint {
+    DatabaseEndpoint {
         connection: connection.to_string(),
         path: path.to_string(),
         role: role.to_string(),
         static_role: static_role.to_string(),
         username: "postgres".to_string(),
-    })
+    }
 }

--- a/vaultrs-tests/tests/api_tests/identity.rs
+++ b/vaultrs-tests/tests/api_tests/identity.rs
@@ -82,7 +82,7 @@ async fn test_group_and_group_alias() {
 }
 
 async fn test_create_entity(client: &VaultClient) -> String {
-    let entity = identity::entity::create(
+    identity::entity::create(
         client,
         Some(
             &mut CreateEntityRequestBuilder::default()
@@ -91,9 +91,8 @@ async fn test_create_entity(client: &VaultClient) -> String {
         ),
     )
     .await
-    .unwrap();
-
-    entity.id
+    .unwrap()
+    .id
 }
 
 async fn create_anonymous_entity(client: &VaultClient) {
@@ -117,14 +116,12 @@ async fn test_read_entity_by_id(client: &VaultClient, expected_id: &str) {
 
 async fn test_list_entity_by_id(client: &VaultClient, expected_id: &str) {
     let entities = identity::entity::list_by_id(client).await.unwrap();
-    assert_eq!(entities.keys.len(), 1);
-    assert_eq!(entities.keys[0], expected_id);
+    assert_eq!(entities.keys, [expected_id]);
 }
 
 async fn test_list_entity_by_name(client: &VaultClient) {
     let entities = identity::entity::list_by_name(client).await.unwrap();
-    assert_eq!(entities.keys.len(), 1);
-    assert_eq!(entities.keys[0], ENTITY_NEW_NAME);
+    assert_eq!(entities.keys, [ENTITY_NEW_NAME]);
 }
 
 async fn test_update_entity_by_id(client: &VaultClient, expected_id: &str) {
@@ -367,8 +364,7 @@ async fn test_delete_entity_alias_by_id(client: &VaultClient, alias_id: &str) {
 
 async fn test_list_entity_alias_by_id(client: &VaultClient, alias_id: &str, expected_id: &str) {
     let aliases = identity::entity_alias::list_by_id(client).await.unwrap();
-    assert_eq!(aliases.keys.len(), 1);
-    assert_eq!(aliases.keys[0], alias_id);
+    assert_eq!(aliases.keys, [alias_id]);
     assert_eq!(aliases.key_info[alias_id].canonical_id, expected_id)
 }
 
@@ -508,8 +504,7 @@ async fn test_delete_group_by_name(client: &VaultClient) {
 
 async fn test_list_groups_by_name(client: &VaultClient) {
     let groups = identity::group::list_by_name(client).await.unwrap();
-    assert_eq!(groups.keys.len(), 1);
-    assert_eq!(groups.keys[0], GROUP_NAME);
+    assert_eq!(groups.keys, [GROUP_NAME]);
 }
 
 async fn test_group_alias(client: &VaultClient) -> String {
@@ -566,8 +561,7 @@ async fn test_update_group_alias_by_id(client: &VaultClient, group_alias_id: &st
 
 async fn test_list_group_aliases_by_id(client: &VaultClient, group_alias_id: &str) {
     let groups = identity::group_alias::list_by_id(client).await.unwrap();
-    assert_eq!(groups.keys.len(), 1);
-    assert_eq!(groups.keys[0], group_alias_id);
+    assert_eq!(groups.keys, [group_alias_id]);
 }
 
 async fn test_delete_group_alias_by_id(client: &VaultClient, group_alias_id: &str) {

--- a/vaultrs-tests/tests/api_tests/kubernetes.rs
+++ b/vaultrs-tests/tests/api_tests/kubernetes.rs
@@ -29,7 +29,7 @@ async fn test() {
 }
 
 pub async fn test_configure(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
-    let resp = vaultrs::auth::kubernetes::configure(
+    vaultrs::auth::kubernetes::configure(
         client,
         &endpoint.path,
         &endpoint.kubernetes_host,
@@ -40,13 +40,14 @@ pub async fn test_configure(client: &impl Client, endpoint: &KubernetesRoleEndpo
                 .issuer(&endpoint.jtw_issuer),
         ),
     )
-    .await;
-    assert!(resp.is_ok());
+    .await
+    .unwrap();
 }
 
 pub async fn test_read_config(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
-    let res = vaultrs::auth::kubernetes::read_config(client, endpoint.path.as_str()).await;
-    assert!(res.is_ok());
+    vaultrs::auth::kubernetes::read_config(client, endpoint.path.as_str())
+        .await
+        .unwrap();
 }
 
 pub async fn test_login(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
@@ -86,32 +87,33 @@ mod role {
     use vaultrs::api::auth::kubernetes::requests::CreateKubernetesRoleRequest;
 
     pub async fn test_delete(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
-        let res = vaultrs::auth::kubernetes::role::delete(
+        vaultrs::auth::kubernetes::role::delete(
             client,
             endpoint.path.as_str(),
             endpoint.role_name.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
-        let res = vaultrs::auth::kubernetes::role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        vaultrs::auth::kubernetes::role::list(client, endpoint.path.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
-        let res = vaultrs::auth::kubernetes::role::read(
+        vaultrs::auth::kubernetes::role::read(
             client,
             endpoint.path.as_str(),
             endpoint.role_name.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_create(client: &impl Client, endpoint: &KubernetesRoleEndpoint) {
-        let res = vaultrs::auth::kubernetes::role::create(
+        vaultrs::auth::kubernetes::role::create(
             client,
             &endpoint.path,
             &endpoint.role_name,
@@ -122,8 +124,8 @@ mod role {
                     .token_ttl("10m"),
             ),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/kv2.rs
+++ b/vaultrs-tests/tests/api_tests/kv2.rs
@@ -68,101 +68,115 @@ async fn test_kv2_url_encoding(client: &impl Client) {
     let secrets = kv2::list(client, path, "path/to/some secret/")
         .await
         .unwrap();
-    assert_eq!(secrets.len(), 1);
-    assert_eq!(secrets.first().unwrap(), "password name with whitespace");
+    assert_eq!(secrets, ["password name with whitespace"]);
 
-    let res: Result<TestSecret, _> = kv2::read(client, path, name).await;
-    assert!(res.is_ok());
-    assert_eq!(res.unwrap().key, endpoint.secret.key);
+    assert_eq!(
+        kv2::read::<TestSecret>(client, path, name)
+            .await
+            .unwrap()
+            .key,
+        endpoint.secret.key
+    );
 }
 
 async fn test_delete_latest(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::delete_latest(client, endpoint.path.as_str(), endpoint.name.as_str()).await;
-    assert!(res.is_ok());
+    kv2::delete_latest(client, endpoint.path.as_str(), endpoint.name.as_str())
+        .await
+        .unwrap();
 }
 
 async fn test_delete_metadata(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::delete_metadata(client, endpoint.path.as_str(), endpoint.name.as_str()).await;
-    assert!(res.is_ok());
+    kv2::delete_metadata(client, endpoint.path.as_str(), endpoint.name.as_str())
+        .await
+        .unwrap();
 }
 
 async fn test_delete_versions(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::delete_versions(
+    kv2::delete_versions(
         client,
         endpoint.path.as_str(),
         endpoint.name.as_str(),
         vec![1],
     )
-    .await;
-    assert!(res.is_ok());
+    .await
+    .unwrap();
 }
 
 async fn test_destroy_versions(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::destroy_versions(
+    kv2::destroy_versions(
         client,
         endpoint.path.as_str(),
         endpoint.name.as_str(),
         vec![1],
     )
-    .await;
-    assert!(res.is_ok());
+    .await
+    .unwrap();
 }
 
 async fn test_list(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::list(client, endpoint.path.as_str(), "").await;
-    assert!(res.is_ok());
-    assert!(!res.unwrap().is_empty());
+    assert!(!kv2::list(client, endpoint.path.as_str(), "")
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 async fn test_read(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res: Result<TestSecret, _> = kv2::read(client, endpoint.path.as_str(), "test").await;
-    assert!(res.is_ok());
-    assert_eq!(res.unwrap().key, endpoint.secret.key);
+    assert_eq!(
+        kv2::read::<TestSecret>(client, endpoint.path.as_str(), "test")
+            .await
+            .unwrap()
+            .key,
+        endpoint.secret.key
+    );
 }
 
 async fn test_read_metadata(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::read_metadata(client, endpoint.path.as_str(), endpoint.name.as_str()).await;
-    assert!(res.is_ok());
-    let response = res.unwrap();
+    let response = kv2::read_metadata(client, endpoint.path.as_str(), endpoint.name.as_str())
+        .await
+        .unwrap();
     assert!(!response.versions.is_empty());
     assert!(!response.custom_metadata.unwrap().is_empty());
 }
 
 async fn test_read_version(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res: Result<TestSecret, _> =
-        kv2::read_version(client, endpoint.path.as_str(), "test", 1).await;
-    assert!(res.is_ok());
-    assert_eq!(res.unwrap().key, endpoint.secret.key);
+    assert_eq!(
+        kv2::read_version::<TestSecret>(client, endpoint.path.as_str(), "test", 1)
+            .await
+            .unwrap()
+            .key,
+        endpoint.secret.key
+    );
 }
 
 async fn test_set(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::set(client, endpoint.path.as_str(), "test", &endpoint.secret).await;
-    assert!(res.is_ok());
+    kv2::set(client, endpoint.path.as_str(), "test", &endpoint.secret)
+        .await
+        .unwrap();
 }
 
 async fn test_set_with_compare_and_swap(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::set_with_options(
+    kv2::set_with_options(
         client,
         endpoint.path.as_str(),
         "test-compare-and-swap",
         &endpoint.secret,
         SetSecretRequestOptions { cas: 0 },
     )
-    .await;
-    assert!(res.is_ok());
-    let res = kv2::set_with_options(
+    .await
+    .unwrap();
+    kv2::set_with_options(
         client,
         endpoint.path.as_str(),
         "test-compare-and-swap",
         &endpoint.secret,
         SetSecretRequestOptions { cas: 0 },
     )
-    .await;
-    assert!(res.is_err());
+    .await
+    .unwrap_err();
 }
 
 async fn test_set_metadata(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::set_metadata(
+    kv2::set_metadata(
         client,
         endpoint.path.as_str(),
         endpoint.name.as_str(),
@@ -175,19 +189,19 @@ async fn test_set_metadata(client: &impl Client, endpoint: &SecretEndpoint) {
                 ])),
         ),
     )
-    .await;
-    assert!(res.is_ok());
+    .await
+    .unwrap();
 }
 
 async fn test_undelete_versions(client: &impl Client, endpoint: &SecretEndpoint) {
-    let res = kv2::undelete_versions(
+    kv2::undelete_versions(
         client,
         endpoint.path.as_str(),
         endpoint.name.as_str(),
         vec![1],
     )
-    .await;
-    assert!(res.is_ok());
+    .await
+    .unwrap();
 }
 
 mod config {
@@ -196,14 +210,12 @@ mod config {
     use super::SecretEndpoint;
 
     pub async fn test_read(client: &impl Client, endpoint: &SecretEndpoint) {
-        let resp = config::read(client, endpoint.path.as_str()).await;
-
-        assert!(resp.is_ok());
+        config::read(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &SecretEndpoint) {
         let versions: u64 = 100;
-        let resp = config::set(
+        config::set(
             client,
             endpoint.path.as_str(),
             Some(
@@ -212,9 +224,8 @@ mod config {
                     .delete_version_after("768h"),
             ),
         )
-        .await;
-
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/login.rs
+++ b/vaultrs-tests/tests/api_tests/login.rs
@@ -12,6 +12,7 @@ use vaultrs_login::LoginClient;
 use crate::common::Test;
 
 #[tokio::test]
+#[ignore]
 async fn test() {
     let mut test = Test::builder()
         .with_localstack(["iam", "sts"])

--- a/vaultrs-tests/tests/api_tests/login.rs
+++ b/vaultrs-tests/tests/api_tests/login.rs
@@ -70,11 +70,10 @@ async fn test_list(client: &VaultClient) {
 async fn test_list_supported(client: &VaultClient) {
     debug!("running test...");
 
-    let res = method::list_supported(client).await;
-    assert!(res.is_ok());
-
-    let res = res.unwrap();
-    assert_eq!(res.keys().len(), 4);
+    assert_eq!(
+        method::list_supported(client).await.unwrap().keys().len(),
+        4
+    );
 }
 
 #[instrument(skip(client))]
@@ -82,23 +81,25 @@ async fn test_approle(client: &mut VaultClient) {
     debug!("running test...");
 
     // Create role
-    let res = approle::role::set(
+    approle::role::set(
         client,
         "approle_test",
         "test",
         Some(&mut SetAppRoleRequest::builder().token_ttl("10m")),
     )
-    .await;
-    assert!(res.is_ok());
+    .await
+    .unwrap();
 
     // Fetch details
-    let res = approle::role::read_id(client, "approle_test", "test").await;
-    assert!(res.is_ok());
-    let role_id = res.unwrap().role_id;
+    let role_id = approle::role::read_id(client, "approle_test", "test")
+        .await
+        .unwrap()
+        .role_id;
 
-    let res = approle::role::secret::generate(client, "approle_test", "test", None).await;
-    assert!(res.is_ok());
-    let secret_id = res.unwrap().secret_id;
+    let secret_id = approle::role::secret::generate(client, "approle_test", "test", None)
+        .await
+        .unwrap()
+        .secret_id;
 
     // Test login
     client
@@ -300,7 +301,6 @@ async fn test_aws(localstack_url: &str, client: &mut VaultClient) {
         header_value: None,
     };
 
-    let res = client.login(mount, &login).await;
-    assert!(res.is_ok());
+    client.login(mount, &login).await.unwrap();
     client.lookup().await.unwrap();
 }

--- a/vaultrs-tests/tests/api_tests/oidc.rs
+++ b/vaultrs-tests/tests/api_tests/oidc.rs
@@ -31,14 +31,12 @@ mod config {
     use super::OIDCEndpoint;
 
     pub async fn test_read(client: &impl Client, endpoint: &OIDCEndpoint) {
-        let resp = config::read(client, endpoint.path.as_str()).await;
-
-        assert!(resp.is_ok());
+        config::read(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &OIDCEndpoint) {
         // TODO: This might not always work
-        let resp = config::set(
+        config::set(
             client,
             endpoint.path.as_str(),
             Some(
@@ -50,8 +48,8 @@ mod config {
                     ),
             ),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -60,22 +58,23 @@ mod role {
     use vaultrs::{api::auth::oidc::requests::SetRoleRequest, auth::oidc::role};
 
     pub async fn test_delete(client: &impl Client, endpoint: &OIDCEndpoint) {
-        let res = role::delete(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::delete(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &OIDCEndpoint) {
-        let res = role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        role::list(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &OIDCEndpoint) {
-        let res = role::read(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::read(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &OIDCEndpoint) {
-        let res = role::set(
+        role::set(
             client,
             endpoint.path.as_str(),
             endpoint.role.as_str(),
@@ -83,8 +82,8 @@ mod role {
             vec!["https://samples.auth0.com/authorize".to_string()],
             Some(&mut SetRoleRequest::builder()),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/ssh.rs
+++ b/vaultrs-tests/tests/api_tests/ssh.rs
@@ -41,39 +41,39 @@ async fn test() {
 }
 
 pub async fn test_generate_dyn(client: &impl Client, endpoint: &SSHEndpoint) {
-    let res = vaultrs::ssh::generate(
+    let err = vaultrs::ssh::generate(
         client,
         endpoint.path.as_str(),
         endpoint.dyn_role.as_str(),
         "192.168.1.1",
         Some("admin".to_string()),
     )
-    .await;
+    .await
+    .unwrap_err();
 
     // This will fail since we don't have a valid SSH server at the configured IP
-    assert!(res.is_err());
-    if let ClientError::APIError { code, errors: _ } = res.unwrap_err() {
+    if let ClientError::APIError { code, errors: _ } = err {
         assert_eq!(code, 500);
     }
 }
 
 pub async fn test_generate_otp(client: &impl Client, endpoint: &SSHEndpoint) -> String {
-    let res = vaultrs::ssh::generate(
+    vaultrs::ssh::generate(
         client,
         endpoint.path.as_str(),
         endpoint.otp_role.as_str(),
         "192.168.1.1",
         Some("admin".to_string()),
     )
-    .await;
-
-    assert!(res.is_ok());
-    res.unwrap().key
+    .await
+    .unwrap()
+    .key
 }
 
 pub async fn test_verify_otp(client: &impl Client, endpoint: &SSHEndpoint, otp: String) {
-    let res = vaultrs::ssh::verify_otp(client, endpoint.path.as_str(), otp.as_str()).await;
-    assert!(res.is_ok());
+    vaultrs::ssh::verify_otp(client, endpoint.path.as_str(), otp.as_str())
+        .await
+        .unwrap();
 }
 
 pub mod ca {
@@ -82,44 +82,41 @@ pub mod ca {
     use vaultrs::ssh::ca;
 
     pub async fn test_delete(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = ca::delete(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        ca::delete(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_generate(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = ca::generate(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        ca::generate(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = ca::read(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        ca::read(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_sign(client: &impl Client, endpoint: &SSHEndpoint) {
         let public_key = fs::read_to_string("tests/files/id_rsa.pub").unwrap();
-        let res = ca::sign(
+        ca::sign(
             client,
             endpoint.path.as_str(),
             endpoint.role.as_str(),
             public_key.as_str(),
             None,
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_submit(client: &impl Client, endpoint: &SSHEndpoint) {
         let private_key = fs::read_to_string("tests/files/id_rsa").unwrap();
         let public_key = fs::read_to_string("tests/files/id_rsa.pub").unwrap();
-        let res = ca::set(
+        ca::set(
             client,
             endpoint.path.as_str(),
             private_key.as_str(),
             public_key.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -130,19 +127,20 @@ pub mod key {
 
     pub async fn test_set(client: &impl Client, endpoint: &SSHEndpoint) {
         let key = fs::read_to_string("tests/files/id_rsa").unwrap();
-        let res = key::set(
+        key::set(
             client,
             endpoint.path.as_str(),
             endpoint.role.as_str(),
             key.as_str(),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_delete(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = key::delete(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        key::delete(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 }
 
@@ -151,22 +149,23 @@ mod role {
     use vaultrs::{api::ssh::requests::SetRoleRequest, ssh::role};
 
     pub async fn test_delete(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = role::delete(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::delete(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = role::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        role::list(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = role::read(client, endpoint.path.as_str(), endpoint.role.as_str()).await;
-        assert!(res.is_ok());
+        role::read(client, endpoint.path.as_str(), endpoint.role.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = role::set(
+        role::set(
             client,
             endpoint.path.as_str(),
             endpoint.role.as_str(),
@@ -177,8 +176,8 @@ mod role {
                     .allow_user_certificates(true),
             ),
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -187,18 +186,17 @@ pub mod zero {
     use vaultrs::ssh::zero;
 
     pub async fn test_set(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = zero::set(client, endpoint.path.as_str(), vec![endpoint.role.clone()]).await;
-        assert!(res.is_ok());
+        zero::set(client, endpoint.path.as_str(), vec![endpoint.role.clone()])
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = zero::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        zero::list(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_delete(client: &impl Client, endpoint: &SSHEndpoint) {
-        let res = zero::delete(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        zero::delete(client, endpoint.path.as_str()).await.unwrap();
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/sys.rs
+++ b/vaultrs-tests/tests/api_tests/sys.rs
@@ -1,8 +1,3 @@
-// mod common;
-// mod vault_prod_container;
-
-// use common::{VaultServer, VaultServerHelper, PORT, VERSION};
-// use dockertest_server::Test;
 use vaultrs::{
     api::{sys::requests::ListMountsRequest, ResponseWrapper},
     client::Client,

--- a/vaultrs-tests/tests/api_tests/sys.rs
+++ b/vaultrs-tests/tests/api_tests/sys.rs
@@ -61,23 +61,16 @@ async fn sys_init() {
 
 async fn test_wrap(client: &impl Client) {
     let endpoint = ListMountsRequest::builder().build().unwrap();
-    let wrap_resp = endpoint.wrap(client).await;
-    assert!(wrap_resp.is_ok());
+    let wrap_resp = endpoint.wrap(client).await.unwrap();
+    wrap_resp.lookup(client).await.unwrap();
 
-    let wrap_resp = wrap_resp.unwrap();
-    let info = wrap_resp.lookup(client).await;
-    assert!(info.is_ok());
+    wrap_resp.unwrap(client).await.unwrap();
 
-    let unwrap_resp = wrap_resp.unwrap(client).await;
-    assert!(unwrap_resp.is_ok());
-
-    let info = wrap_resp.lookup(client).await;
-    assert!(info.is_err());
+    wrap_resp.lookup(client).await.unwrap_err();
 }
 
 async fn test_health(client: &impl Client) {
-    let resp = sys::health(client).await;
-    assert!(resp.is_ok());
+    sys::health(client).await.unwrap();
 }
 
 async fn test_start_initialization_failure(client: &impl Client) {
@@ -96,14 +89,14 @@ async fn test_start_initialization(client: &impl Client) {
 }
 
 async fn test_seal(client: &impl Client) {
-    let resp = sys::seal(client).await;
-    assert!(resp.is_ok());
+    sys::seal(client).await.unwrap();
 }
 
 async fn test_status(client: &impl Client) {
-    let resp = sys::status(client).await;
-    assert!(resp.is_ok());
-    assert!(matches!(resp.unwrap(), sys::ServerStatus::OK));
+    assert!(matches!(
+        sys::status(client).await.unwrap(),
+        sys::ServerStatus::OK
+    ));
 }
 
 mod mount {
@@ -111,13 +104,13 @@ mod mount {
     use vaultrs::sys::mount;
 
     pub async fn test_create_mount(client: &impl Client) {
-        let resp = mount::enable(client, "pki_temp", "pki", None).await;
-        assert!(resp.is_ok());
+        mount::enable(client, "pki_temp", "pki", None)
+            .await
+            .unwrap();
     }
 
     pub async fn test_list_mount(client: &impl Client) {
-        let resp = mount::list(client).await;
-        assert!(resp.is_ok());
+        mount::list(client).await.unwrap();
     }
     pub async fn test_get_configuration_of_a_secret_engine(client: &impl Client) {
         mount::get_configuration_of_a_secret_engine(client, "pki_temp")
@@ -127,11 +120,9 @@ mod mount {
 
     pub async fn test_delete_mount(client: &impl Client) {
         mount::disable(client, "pki_temp").await.unwrap();
-        assert!(
-            mount::get_configuration_of_a_secret_engine(client, "pki_temp")
-                .await
-                .is_err()
-        );
+        mount::get_configuration_of_a_secret_engine(client, "pki_temp")
+            .await
+            .unwrap_err();
     }
 }
 
@@ -140,13 +131,13 @@ mod auth {
     use vaultrs::sys::auth;
 
     pub async fn test_create_auth(client: &impl Client) {
-        let resp = auth::enable(client, "oidc_temp", "oidc", None).await;
-        assert!(resp.is_ok());
+        auth::enable(client, "oidc_temp", "oidc", None)
+            .await
+            .unwrap();
     }
 
     pub async fn test_list_auth(client: &impl Client) {
-        let resp = auth::list(client).await;
-        assert!(resp.is_ok());
+        auth::list(client).await.unwrap();
     }
 }
 
@@ -155,18 +146,15 @@ mod policy {
     use vaultrs::sys::policy;
 
     pub async fn test_delete_policy(client: &impl Client) {
-        let resp = policy::delete(client, "test").await;
-        assert!(resp.is_ok());
+        policy::delete(client, "test").await.unwrap();
     }
 
     pub async fn test_list_policies(client: &impl Client) {
-        let resp = policy::list(client).await;
-        assert!(resp.is_ok());
+        policy::list(client).await.unwrap();
     }
 
     pub async fn test_read_policy(client: &impl Client) {
-        let resp = policy::read(client, "test").await;
-        assert!(resp.is_ok());
+        policy::read(client, "test").await.unwrap();
     }
 
     pub async fn test_set_policy(client: &impl Client) {
@@ -175,8 +163,7 @@ mod policy {
                 capabilities = ["list"]
             }"#;
 
-        let resp = policy::set(client, "test", policy).await;
-        assert!(resp.is_ok());
+        policy::set(client, "test", policy).await.unwrap();
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/token.rs
+++ b/vaultrs-tests/tests/api_tests/token.rs
@@ -43,71 +43,61 @@ async fn test() {
 }
 
 pub async fn test_lookup(client: &impl Client, token: &str) {
-    let resp = token::lookup(client, token).await;
-    assert!(resp.is_ok());
+    token::lookup(client, token).await.unwrap();
 }
 
 pub async fn test_lookup_accessor(client: &impl Client, accessor: &str) {
-    let resp = token::lookup_accessor(client, accessor).await;
-    assert!(resp.is_ok());
+    token::lookup_accessor(client, accessor).await.unwrap();
 }
 
 pub async fn test_lookup_self(client: &impl Client) {
-    let resp = token::lookup_self(client).await;
-    assert!(resp.is_ok());
+    token::lookup_self(client).await.unwrap();
 }
 
 pub async fn test_new(client: &impl Client) {
-    let resp = token::new(client, None).await;
-    assert!(resp.is_ok());
+    token::new(client, None).await.unwrap();
 }
 
 pub async fn test_new_orphan(client: &impl Client) {
-    let resp = token::new_orphan(client, None).await;
-    assert!(resp.is_ok());
+    token::new_orphan(client, None).await.unwrap();
 }
 
 pub async fn test_renew(client: &impl Client, token: &str) {
-    let resp = token::renew(client, token, Some("20m")).await;
-    assert!(resp.is_ok());
+    token::renew(client, token, Some("20m")).await.unwrap();
 }
 
 pub async fn test_renew_accessor(client: &impl Client, accessor: &str) {
-    let resp = token::renew_accessor(client, accessor, Some("20m")).await;
-    assert!(resp.is_ok());
+    token::renew_accessor(client, accessor, Some("20m"))
+        .await
+        .unwrap();
 }
 
 pub async fn test_renew_self(client: &impl Client) {
     let resp = token::renew_self(client, Some("20m")).await;
-    assert!(resp.is_err()); // Cannot renew the root token
+    // Cannot renew the root token
     if let ClientError::APIError { code: _, errors } = resp.unwrap_err() {
         assert_eq!(errors[0], "lease is not renewable");
     }
 }
 
 pub async fn test_revoke(client: &impl Client, token: &str) {
-    let resp = token::revoke(client, token).await;
-    assert!(resp.is_ok());
+    token::revoke(client, token).await.unwrap();
 }
 
 pub async fn test_revoke_accessor(client: &impl Client, accessor: &str) {
-    let resp = token::revoke_accessor(client, accessor).await;
-    assert!(resp.is_ok());
+    token::revoke_accessor(client, accessor).await.unwrap();
 }
 
 pub async fn test_revoke_orphan(client: &impl Client, token: &str) {
-    let resp = token::revoke_orphan(client, token).await;
-    assert!(resp.is_ok());
+    token::revoke_orphan(client, token).await.unwrap();
 }
 
 pub async fn test_revoke_self(client: &impl Client) {
-    let resp = token::revoke_self(client).await;
-    assert!(resp.is_ok());
+    token::revoke_self(client).await.unwrap();
 }
 
 pub async fn test_tidy(client: &impl Client) {
-    let resp = token::tidy(client).await;
-    assert!(resp.is_ok());
+    token::tidy(client).await.unwrap();
 }
 
 mod role {
@@ -117,22 +107,19 @@ mod role {
     use super::Client;
 
     pub async fn test_delete(client: &impl Client, role_name: &str) {
-        let resp = role::delete(client, role_name).await;
-        assert!(resp.is_ok());
+        role::delete(client, role_name).await.unwrap();
     }
 
     pub async fn test_list(client: &impl Client) {
-        let resp = role::list(client).await;
-        assert!(resp.is_ok());
+        role::list(client).await.unwrap();
     }
 
     pub async fn test_read(client: &impl Client, role_name: &str) {
-        let resp = role::read(client, role_name).await;
-        assert!(resp.is_ok());
+        role::read(client, role_name).await.unwrap();
     }
 
     pub async fn test_set(client: &impl Client, role_name: &str) {
-        let resp = role::set(
+        role::set(
             client,
             role_name,
             Some(
@@ -141,8 +128,8 @@ mod role {
                     .token_explicit_max_ttl("1h"),
             ),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/transit.rs
+++ b/vaultrs-tests/tests/api_tests/transit.rs
@@ -43,10 +43,11 @@ mod key {
     use vaultrs::transit::key;
 
     pub async fn test_create(endpoint: &TransitEndpoint<'_>) {
-        let resp = key::create(endpoint.client, &endpoint.path, &endpoint.keys.basic, None).await;
-        assert!(resp.is_ok());
+        key::create(endpoint.client, &endpoint.path, &endpoint.keys.basic, None)
+            .await
+            .unwrap();
 
-        let resp = key::create(
+        key::create(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.export,
@@ -59,13 +60,14 @@ mod key {
                     .auto_rotate_period("30d"),
             ),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
 
-        let resp = key::create(endpoint.client, &endpoint.path, &endpoint.keys.delete, None).await;
-        assert!(resp.is_ok());
+        key::create(endpoint.client, &endpoint.path, &endpoint.keys.delete, None)
+            .await
+            .unwrap();
 
-        let resp = key::create(
+        key::create(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.signing,
@@ -75,10 +77,10 @@ mod key {
                     .key_type(KeyType::Ed25519),
             ),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
 
-        let resp = key::create(
+        key::create(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.asymmetric,
@@ -89,8 +91,8 @@ mod key {
                     .key_type(KeyType::Rsa2048),
             ),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_read(endpoint: &TransitEndpoint<'_>) {
@@ -144,16 +146,18 @@ mod key {
 
     pub async fn test_rotate(endpoint: &TransitEndpoint<'_>) {
         // key version 2
-        let resp = key::rotate(endpoint.client, &endpoint.path, &endpoint.keys.export).await;
-        assert!(resp.is_ok());
+        key::rotate(endpoint.client, &endpoint.path, &endpoint.keys.export)
+            .await
+            .unwrap();
 
         // key version 3
-        let resp = key::rotate(endpoint.client, &endpoint.path, &endpoint.keys.export).await;
-        assert!(resp.is_ok());
+        key::rotate(endpoint.client, &endpoint.path, &endpoint.keys.export)
+            .await
+            .unwrap();
     }
 
     pub async fn test_update(endpoint: &TransitEndpoint<'_>) {
-        let resp = key::update(
+        key::update(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.export,
@@ -163,37 +167,39 @@ mod key {
                     .min_decryption_version(2u64),
             ),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
 
-        let resp = key::update(
+        key::update(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.delete,
             Some(UpdateKeyConfigurationRequest::builder().deletion_allowed(true)),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_delete(endpoint: &TransitEndpoint<'_>) {
-        let resp = key::delete(endpoint.client, &endpoint.path, &endpoint.keys.basic).await;
-        assert!(resp.is_err());
+        key::delete(endpoint.client, &endpoint.path, &endpoint.keys.basic)
+            .await
+            .unwrap_err();
 
-        let resp = key::delete(endpoint.client, &endpoint.path, &endpoint.keys.delete).await;
-        assert!(resp.is_ok());
+        key::delete(endpoint.client, &endpoint.path, &endpoint.keys.delete)
+            .await
+            .unwrap();
     }
 
     pub async fn test_export(endpoint: &TransitEndpoint<'_>) {
-        let resp = key::export(
+        key::export(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.basic,
             ExportKeyType::EncryptionKey,
             ExportVersion::All,
         )
-        .await;
-        assert!(resp.is_err());
+        .await
+        .unwrap_err();
 
         let latest = key::export(
             endpoint.client,
@@ -233,30 +239,33 @@ mod key {
     }
 
     pub async fn test_backup_and_restore(endpoint: &TransitEndpoint<'_>) {
-        let resp = key::backup(endpoint.client, &endpoint.path, &endpoint.keys.basic).await;
-        assert!(resp.is_err());
+        key::backup(endpoint.client, &endpoint.path, &endpoint.keys.basic)
+            .await
+            .unwrap_err();
 
         let backup = key::backup(endpoint.client, &endpoint.path, &endpoint.keys.export)
             .await
             .unwrap()
             .backup;
 
-        let resp = key::restore(endpoint.client, &endpoint.path, &endpoint.keys.export, None).await;
-        assert!(resp.is_err());
+        key::restore(endpoint.client, &endpoint.path, &endpoint.keys.export, None)
+            .await
+            .unwrap_err();
 
-        let resp = key::restore(
+        key::restore(
             endpoint.client,
             &endpoint.path,
             &backup,
             Some(RestoreKeyRequest::builder().force(true)),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_trim(endpoint: &TransitEndpoint<'_>) {
-        let resp = key::trim(endpoint.client, &endpoint.path, &endpoint.keys.export, 2).await;
-        assert!(resp.is_ok());
+        key::trim(endpoint.client, &endpoint.path, &endpoint.keys.export, 2)
+            .await
+            .unwrap();
     }
 }
 
@@ -281,8 +290,9 @@ mod data {
         .unwrap();
 
         // key version 4
-        let resp = key::rotate(endpoint.client, &endpoint.path, &endpoint.keys.export).await;
-        assert!(resp.is_ok());
+        key::rotate(endpoint.client, &endpoint.path, &endpoint.keys.export)
+            .await
+            .unwrap();
 
         let rewrapped = data::rewrap(
             endpoint.client,
@@ -403,15 +413,15 @@ mod generate {
     }
 
     pub async fn test_hmac(endpoint: &TransitEndpoint<'_>) {
-        let resp = generate::hmac(
+        generate::hmac(
             endpoint.client,
             &endpoint.path,
             &endpoint.keys.basic,
             &endpoint.data.context,
             None,
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
     }
 }
 
@@ -421,16 +431,21 @@ mod cache {
     use vaultrs::transit::cache;
 
     pub async fn test_configure_and_read(endpoint: &TransitEndpoint<'_>) {
-        let resp = cache::configure(
+        cache::configure(
             endpoint.client,
             &endpoint.path,
             Some(ConfigureCacheRequest::builder().size(123u64)),
         )
-        .await;
-        assert!(resp.is_ok());
+        .await
+        .unwrap();
 
-        let resp = cache::read(endpoint.client, &endpoint.path).await.unwrap();
-        assert_eq!(resp.size, 123);
+        assert_eq!(
+            cache::read(endpoint.client, &endpoint.path)
+                .await
+                .unwrap()
+                .size,
+            123
+        );
     }
 }
 

--- a/vaultrs-tests/tests/api_tests/userpass.rs
+++ b/vaultrs-tests/tests/api_tests/userpass.rs
@@ -26,14 +26,14 @@ async fn test() {
 }
 
 pub async fn test_login(client: &impl Client, endpoint: &UserPassEndpoint) {
-    let res = userpass::login(
+    userpass::login(
         client,
         endpoint.path.as_str(),
         endpoint.username.as_str(),
         endpoint.password.as_str(),
     )
-    .await;
-    assert!(res.is_ok());
+    .await
+    .unwrap();
 }
 
 pub mod user {
@@ -41,52 +41,53 @@ pub mod user {
     use vaultrs::auth::userpass::user;
 
     pub async fn test_delete(client: &impl Client, endpoint: &UserPassEndpoint) {
-        let res = user::delete(client, endpoint.path.as_str(), endpoint.username.as_str()).await;
-        assert!(res.is_ok());
+        user::delete(client, endpoint.path.as_str(), endpoint.username.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_list(client: &impl Client, endpoint: &UserPassEndpoint) {
-        let res = user::list(client, endpoint.path.as_str()).await;
-        assert!(res.is_ok());
+        user::list(client, endpoint.path.as_str()).await.unwrap();
     }
 
     pub async fn test_read(client: &impl Client, endpoint: &UserPassEndpoint) {
-        let res = user::read(client, endpoint.path.as_str(), endpoint.username.as_str()).await;
-        assert!(res.is_ok());
+        user::read(client, endpoint.path.as_str(), endpoint.username.as_str())
+            .await
+            .unwrap();
     }
 
     pub async fn test_set(client: &impl Client, endpoint: &UserPassEndpoint) {
-        let res = user::set(
+        user::set(
             client,
             endpoint.path.as_str(),
             endpoint.username.as_str(),
             endpoint.password.as_str(),
             None,
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_update_password(client: &impl Client, endpoint: &UserPassEndpoint) {
-        let res = user::update_password(
+        user::update_password(
             client,
             endpoint.path.as_str(),
             endpoint.username.as_str(),
             "This1sAT3st!!",
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 
     pub async fn test_update_policies(client: &impl Client, endpoint: &UserPassEndpoint) {
-        let res = user::update_policies(
+        user::update_policies(
             client,
             endpoint.path.as_str(),
             endpoint.username.as_str(),
             "default",
         )
-        .await;
-        assert!(res.is_ok());
+        .await
+        .unwrap();
     }
 }
 


### PR DESCRIPTION
Cleanup the further the testsuite by doing the following:

- Remove `assert!(result.is_ok())` pattern, which gives less context in case of failure than `result.unwrap()`
- Move the example of the README directly inside the `lib.rs` to compile them. Fix some examples that silently didn't compile until then.
- Fix doc generation warning and add a ci check for it
- Detect slow test with `cargo +nightly t --workspace -- -Z unstable-options --report-time --format json 2> /dev/null | jq` and ignore them locally. This improves the developer experience.
- Update README to new test location since `testscontainers` migration

I split the PR into several commits to ease the review.