### PR TITLE
Move to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,42 +25,42 @@ authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
 repository = "https://github.com/jmgilman/vaultrs"
 
 [workspace.dependencies]
-async-trait = "0.1.68"
-aws-credential-types = { version = "1.1.5" }
-aws-sdk-iam = { version = "1.13" }
-aws-sdk-sts = { version = "1.13" }
-aws-sigv4 = { version = "1.1" }
-aws-smithy-runtime-api = { version = "1.1.5" }
-aws-types = { version = "1.1" }
-base64 = { version = "0.21" }
-bytes = "1.4.0"
-chrono = "0.4.38"
-data-encoding = "2.3.3"
-derive_builder = "0.12.0"
-env_logger = "0.10.0"
-hmac = "0.12.1"
-http = "1"
-jwt = "0.16.0"
-rcgen = "0.13"
+async-trait = { version = "0.1.68", default-features = false }
+aws-credential-types = { version = "1.1.5", default-features = false }
+aws-sdk-iam = { version = "1.13", default-features = false, features = ["rt-tokio", "rustls"]}
+aws-sdk-sts = { version = "1.13", default-features = false }
+aws-sigv4 = { version = "1.1", default-features = false  }
+aws-smithy-runtime-api = { version = "1.1.5", default-features = false }
+aws-types = { version = "1.1", default-features = false }
+base64 = { version = "0.21", default-features = false  }
+bytes = { version = "1.4.0", default-features = false }
+chrono = { version = "0.4.38", default-features = false }
+data-encoding = { version = "2.3.3", default-features = false }
+derive_builder = { version = "0.12.0", default-features = false }
+env_logger = { version = "0.10.0", default-features = false }
+hmac = { version = "0.12", default-features = false }
+http = { version =  "1", default-features = false }
+jwt = { version = "0.16.0", default-features = false }
+rcgen = { version = "0.13", default-features = false }
 reqwest = { version = "0.12.2", default-features = false }
-rustify_derive = "0.5.2"
+rustify_derive = { version = "0.5.2", default-features = false }
 rustify = { version = "0.6.0", default-features = false }
-serde_json = "1.0.94"
-serde = { version = "1.0.158", features = ["derive"] }
-serial_test = "1.0.0"
-sha2 = "0.10.6"
-tempfile = "3.10.1"
-testcontainers-modules = { version = "0.11.3", features = ["localstack", "postgres"] }
-testcontainers =  { version = "0.23.1", features = ["http_wait"] }
-test-log = { version = "0.2.11", features = ["trace"] }
-thiserror = "1.0.40"
-tiny_http = { version = "0.12.0" }
-tokio-test = "0.4.2"
-tokio = { version = "1.26.0" }
+serde_json = { version = "1.0.94", default-features = false }
+serde = { version = "1.0.158", default-features = false, features = ["derive", "std"] }
+serial_test = { version = "1.0.0", default-features = false }
+sha2 = { version = "0.10.6", default-features = false }
+tempfile = { version = "3.10.1", default-features = false }
+testcontainers-modules = { version = "0.11.3", default-features = false, features = ["localstack", "postgres"] }
+testcontainers =  { version = "0.23.1", default-features = false, features = ["http_wait"] }
+test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+thiserror = { version = "1.0.40", default-features = false }
+tiny_http = { version = "0.12.0", default-features = false }
+tokio-test = { version = "0.4.2", default-features = false }
+tokio = { version = "1.26.0", default-features = false, features = ["macros", "rt-multi-thread"]}
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
-tracing-test = "0.2.4"
-tracing = { version = "0.1.37", features = ["log"] }
-url = "2.3.1"
+tracing-test = { version = "0.2.4", default-features = false }
+tracing = { version = "0.1.37",  default-features = false, features = ["log"] }
+url = { version = "2.3.1", default-features = false }
 vaultrs-login = { path = "../vaultrs-login", features = ["oidc", "aws"]}
 vaultrs = { version = "0.7.3", path = ".." }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vaultrs"
 version = "0.7.3"
-authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
+authors.workspace = true 
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "An asynchronous Rust client library for the Hashicorp Vault API."
-license = "MIT"
 readme = "README.md"
-repository = "https://github.com/jmgilman/vaultrs"
 keywords = ["Vault", "API", "Client", "Hashicorp"]
-edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,6 +18,52 @@ members = [
 
 default-members = ["vaultrs-login", "vaultrs-tests", "."]
 
+[workspace.package]
+edition = "2021"
+license = "MIT"
+authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
+repository = "https://github.com/jmgilman/vaultrs"
+
+[workspace.dependencies]
+async-trait = "0.1.68"
+aws-credential-types = { version = "1.1.5" }
+aws-sdk-iam = { version = "1.13" }
+aws-sdk-sts = { version = "1.13" }
+aws-sigv4 = { version = "1.1" }
+aws-smithy-runtime-api = { version = "1.1.5" }
+aws-types = { version = "1.1" }
+base64 = { version = "0.21" }
+bytes = "1.4.0"
+chrono = "0.4.38"
+data-encoding = "2.3.3"
+derive_builder = "0.12.0"
+env_logger = "0.10.0"
+hmac = "0.12.1"
+http = "1"
+jwt = "0.16.0"
+rcgen = "0.13"
+reqwest = { version = "0.12.2", default-features = false }
+rustify_derive = "0.5.2"
+rustify = { version = "0.6.0", default-features = false }
+serde_json = "1.0.94"
+serde = { version = "1.0.158", features = ["derive"] }
+serial_test = "1.0.0"
+sha2 = "0.10.6"
+tempfile = "3.10.1"
+testcontainers-modules = { version = "0.11.3", features = ["localstack", "postgres"] }
+testcontainers =  { version = "0.23.1", features = ["http_wait"] }
+test-log = { version = "0.2.11", features = ["trace"] }
+thiserror = "1.0.40"
+tiny_http = { version = "0.12.0" }
+tokio-test = "0.4.2"
+tokio = { version = "1.26.0" }
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
+tracing-test = "0.2.4"
+tracing = { version = "0.1.37", features = ["log"] }
+url = "2.3.1"
+vaultrs-login = { path = "../vaultrs-login", features = ["oidc", "aws"]}
+vaultrs = { version = "0.7.3", path = ".." }
+
 [features]
 default = [ "rustls" ]
 rustls = [ "reqwest/rustls-tls", "rustify/rustls-tls" ]
@@ -25,16 +71,16 @@ native-tls = [ "reqwest/default-tls", "reqwest/native-tls", "rustify/default" ]
 native-tls-vendored = [ "reqwest/native-tls-vendored", "rustify/default" ]
 
 [dependencies]
-async-trait = "0.1.68"
-bytes = "1.4.0"
-derive_builder = "0.12.0"
-http = "1"
-reqwest = { version = "0.12.2", default-features = false }
-rustify = { version = "0.6.0", default-features = false }
-rustify_derive = "0.5.2"
-serde = { version = "1.0.158", features = ["derive"] }
-serde_json = "1.0.94"
-thiserror = "1.0.40"
-url = "2.3.1"
-tracing = { version = "0.1.37", features = ["log"] }
+async-trait.workspace = true
+bytes.workspace = true
+derive_builder.workspace = true
+http.workspace = true
+reqwest.workspace = true
+rustify.workspace = true
+rustify_derive.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+url.workspace = true
+tracing.workspace = true
 

--- a/vaultrs-login/Cargo.toml
+++ b/vaultrs-login/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-aws = ["aws-sdk-iam", "aws-sdk-sts", "aws-sigv4", "aws-types", "aws-credential-types", "aws-smithy-runtime-api", "base64", "http", "serde_json"]
-oidc = ["tiny_http", "tokio"]
+aws = ["dep:aws-sdk-iam", "dep:aws-sdk-sts", "dep:aws-sigv4", "dep:aws-types", "dep:aws-credential-types", "dep:aws-smithy-runtime-api", "dep:base64", "dep:http", "dep:serde_json"]
+oidc = ["dep:tiny_http", "dep:tokio"]
 
 [dependencies]
 async-trait.workspace = true

--- a/vaultrs-login/Cargo.toml
+++ b/vaultrs-login/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vaultrs-login"
 version = "0.2.2"
-authors = ["Joshua Gilman <joshuagilman@gmail.com>"]
 description = "Adds login support for Vault clients from vaultrs."
-license = "MIT"
 readme = "README.md"
-repository = "https://github.com/jmgilman/vaultrs"
 keywords = ["Vault", "API", "Client", "Hashicorp", "Login"]
-edition = "2018"
+authors.workspace = true 
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,24 +16,25 @@ aws = ["aws-sdk-iam", "aws-sdk-sts", "aws-sigv4", "aws-types", "aws-credential-t
 oidc = ["tiny_http", "tokio"]
 
 [dependencies]
-async-trait = "0.1.68"
-aws-credential-types = { version = "1.1.5", optional = true }
-aws-sdk-iam = { version = "1.13", optional = true }
-aws-sdk-sts = { version = "1.13", optional = true }
-aws-sigv4 = { version = "1.1", optional = true }
-aws-smithy-runtime-api = { version = "1.1.5", optional = true }
-aws-types = { version = "1.1", optional = true }
-base64 = { version = "0.21", optional = true }
+async-trait.workspace = true
+aws-credential-types = { workspace = true, optional = true }
+aws-sdk-iam = { workspace = true, optional = true }
+aws-sdk-sts = { workspace = true, optional = true }
+aws-sigv4 = { workspace = true, optional = true }
+aws-smithy-runtime-api = { workspace = true, optional = true }
+aws-types = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+# Blocked by https://github.com/smithy-lang/smithy-rs/issues/1925
 http = { version = "0.2", optional = true }
-serde = "1.0.158"
-serde_json = { version = "1", optional = true }
-tiny_http = { version = "0.12.0", optional = true }
-tokio = { version = "1.26.0", optional = true }
-tracing = "0.1.37"
-url = "2.3.1"
+serde_json = { workspace = true, optional = true }
+serde.workspace = true
+tiny_http = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+tracing.workspace = true
+url.workspace = true
 vaultrs = { version = "0.7.3", path = ".." }
 
 [dev-dependencies]
-reqwest = "0.11.15"
-tokio-test = "0.4.2"
-tracing-test = "0.2.4"
+reqwest.workspace = true
+tokio-test.workspace = true
+tracing-test.workspace = true

--- a/vaultrs-tests/Cargo.toml
+++ b/vaultrs-tests/Cargo.toml
@@ -19,18 +19,18 @@ data-encoding.workspace = true
 env_logger.workspace = true
 hmac.workspace = true
 jwt.workspace = true
-rcgen.workspace = true
-reqwest = { workspace =  true, default-features = false }
+rcgen = { workspace = true, features = ["pem", "ring"] }
+reqwest = { workspace =  true }
 serde_json.workspace = true
 serde.workspace = true
 serial_test.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
-testcontainers-modules = { workspace =  true, features = ["localstack", "postgres"] }
-testcontainers =  { workspace =  true, features = ["http_wait"] }
-test-log = { workspace =  true, features = ["trace"] }
-tokio = { workspace =  true, features = ["full"] }
-tracing-subscriber = { workspace  = true, default-features = false, features = ["env-filter", "fmt"] }
+testcontainers-modules = { workspace = true, features = ["localstack", "postgres"] }
+testcontainers =  { workspace = true, features = ["http_wait"] }
+test-log = { workspace = true, features = ["trace"] }
+tokio = { workspace = true }
+tracing-subscriber = { workspace = true,  features = ["env-filter", "fmt"] }
 tracing.workspace = true
 vaultrs-login = { path = "../vaultrs-login", features = ["oidc", "aws"]}
 vaultrs = { path = ".."}

--- a/vaultrs-tests/Cargo.toml
+++ b/vaultrs-tests/Cargo.toml
@@ -1,33 +1,36 @@
 [package]
 name = "vaultrs-tests"
 version = "0.0.0"
-edition = "2021"
 description = "Integration tests for vaultrs and vaultrs login"
 publish = false
+authors.workspace = true 
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dev-dependencies]
-aws-sdk-iam = { version = "1.13" }
-aws-sdk-sts = { version = "1.13" }
-aws-credential-types = { version = "1.1.5" }
-aws-types = { version = "1.1" }
-vaultrs = { path = ".."}
+aws-credential-types.workspace = true
+aws-sdk-iam.workspace = true
+aws-sdk-sts.workspace = true
+aws-types.workspace = true
+base64.workspace = true
+chrono.workspace = true
+data-encoding.workspace = true
+env_logger.workspace = true
+hmac.workspace = true
+jwt.workspace = true
+rcgen.workspace = true
+reqwest = { workspace =  true, default-features = false }
+serde_json.workspace = true
+serde.workspace = true
+serial_test.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
+testcontainers-modules = { workspace =  true, features = ["localstack", "postgres"] }
+testcontainers =  { workspace =  true, features = ["http_wait"] }
+test-log = { workspace =  true, features = ["trace"] }
+tokio = { workspace =  true, features = ["full"] }
+tracing-subscriber = { workspace  = true, default-features = false, features = ["env-filter", "fmt"] }
+tracing.workspace = true
 vaultrs-login = { path = "../vaultrs-login", features = ["oidc", "aws"]}
-reqwest = { version = "0.12.2", default-features = false }
-base64 = "0.21"
-chrono = "0.4.38"
-serde_json = "1.0.94"
-data-encoding = "2.3.3"
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
-test-log = { version = "0.2.11", features = ["trace"] }
-env_logger = "0.10.0"
-testcontainers =  { version = "0.23.1", features = ["http_wait"] }
-testcontainers-modules = { version = "0.11.3", features = ["localstack", "postgres"] }
-jwt = "0.16.0"
-sha2 = "0.10.6"
-hmac = "0.12.1"
-serial_test = "1.0.0"
-rcgen = "0.13"
-tempfile = "3.10.1"
-tokio = { version = "1.40.0", features = ["full"] }
-tracing = "0.1.40"
-serde = "1.0.213"
+vaultrs = { path = ".."}


### PR DESCRIPTION
- Move to workspace dependencies to de-duplicate
- Use `default-features = false` everywhere to reduce compile time
- Use the `dep:` notation in features to disambiguate