### PR TITLE
Fix: remove manually drop from test

### DIFF
--- a/vaultrs-tests/tests/api_tests/sys.rs
+++ b/vaultrs-tests/tests/api_tests/sys.rs
@@ -55,7 +55,6 @@ async fn test() {
 #[tokio::test]
 async fn sys_init() {
     let test = Test::new_prod().await;
-    let test = std::mem::ManuallyDrop::new(test);
     let client = test.client();
     test_start_initialization(client).await;
 }


### PR DESCRIPTION
When I want to manually inspect the vault state after a test, I add a `std::mem::ManuallyDrop` to prevent `Drop` from running and cleaning the Vault. Sadly this one got committed into master.