### PR TITLE
Added support for multiple oidc endpoints

### DIFF
--- a/src/api/identity.rs
+++ b/src/api/identity.rs
@@ -2,3 +2,4 @@ pub mod entity;
 pub mod entity_alias;
 pub mod group;
 pub mod group_alias;
+pub mod oidc;

--- a/src/api/identity/oidc.rs
+++ b/src/api/identity/oidc.rs
@@ -1,0 +1,3 @@
+pub mod named_key;
+pub mod token;
+pub mod role;

--- a/src/api/identity/oidc/named_key.rs
+++ b/src/api/identity/oidc/named_key.rs
@@ -1,0 +1,2 @@
+pub mod requests;
+pub mod responses;

--- a/src/api/identity/oidc/named_key/requests.rs
+++ b/src/api/identity/oidc/named_key/requests.rs
@@ -1,0 +1,49 @@
+use rustify_derive::Endpoint;
+
+/// ## Create a named key.
+///
+/// This endpoint creates a named key.
+///
+/// * Path: identity/oidc/key/{name}
+/// * Method: POST
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#create-a-named-key>
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "identity/oidc/key/{self.name}",
+    method = "POST",
+    builder = "true",
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct CreateNamedKeyRequest {
+    /// Name of the named key.
+    #[endpoint(skip)]
+    pub name: String,
+    /// How often to generate a new signing key. Uses duration format strings.
+    pub rotation_period: Option<String>,
+    /// Controls how long the public portion of a signing key will be available for verification after being rotated. Uses duration format strings.
+    pub verification_ttl: Option<String>,
+    /// Array of role client ids allowed to use this key for signing. If empty, no roles are allowed. If "*", all roles are allowed.
+    pub allowed_client_ids: Vec<String>,
+    /// Signing algorithm to use. Allowed values are: RS256 (default), RS384, RS512, ES256, ES384, ES512, EdDSA.
+    pub signing_algorithm: Option<String>,
+}
+
+/// ## Delete a named key.
+///
+/// This endpoint deletes a named key.
+///
+/// * Path: identity/oidc/key/{name}
+/// * Method: DELETE
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#delete-a-named-key>
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "identity/oidc/key/{self.name}",
+    method = "DELETE",
+    builder = "true",
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct DeleteNamedKeyRequest {
+    /// Name of the named key.
+    #[endpoint(skip)]
+    pub name: String,
+}

--- a/src/api/identity/oidc/role.rs
+++ b/src/api/identity/oidc/role.rs
@@ -1,0 +1,2 @@
+pub mod requests;
+pub mod responses;

--- a/src/api/identity/oidc/role/requests.rs
+++ b/src/api/identity/oidc/role/requests.rs
@@ -1,0 +1,71 @@
+use crate::api::identity::oidc::role::responses::ReadRoleResponse;
+use rustify_derive::Endpoint;
+
+/// ## Create or update a role.
+///
+/// This endpoint creates or updates a role.
+///
+/// * Path: identity/oidc/role/{name}
+/// * Method: POST
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#create-or-update-a-role>
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "identity/oidc/role/{self.name}",
+    method = "POST",
+    builder = "true",
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct SetRoleRequest {
+    /// Name of the role.
+    #[endpoint(skip)]
+    pub name: String,
+    /// A configured named key, the key must already exist.
+    pub key: String,
+    /// The template string to use for generating tokens. This may be in string-ified JSON or base64 format.
+    pub template: Option<String>,
+    /// Optional client ID. A random ID will be generated if left unset.
+    pub client_id: Option<String>,
+    /// TTL of the tokens generated against the role. Uses duration format strings.
+    pub ttl: Option<String>,
+}
+
+/// ## Read a role.
+///
+/// This endpoint reads a role.
+///
+/// * Path: identity/oidc/role/{name}
+/// * Method: GET
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#read-a-role>
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "identity/oidc/role/{self.name}",
+    method = "GET",
+    builder = "true",
+    response = "ReadRoleResponse"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct ReadRoleRequest {
+    /// Name of the role.
+    #[endpoint(skip)]
+    pub name: String,
+}
+
+/// ## Delete a role.
+///
+/// This endpoint deletes a role.
+///
+/// * Path: identity/oidc/role/{name}
+/// * Method: DELETE
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#delete-a-role>
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "identity/oidc/role/{self.name}",
+    method = "DELETE",
+    builder = "true",
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct DeleteRoleRequest {
+    /// Name of the role.
+    #[endpoint(skip)]
+    pub name: String,
+}

--- a/src/api/identity/oidc/role/responses.rs
+++ b/src/api/identity/oidc/role/responses.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from executing
+/// [ReadRoleRequest](crate::api::identity::oidc::role::ReadRoleRequest)
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ReadRoleResponse {
+    client_id: String,
+    key: String,
+    template: String,
+    ttl: String,
+}

--- a/src/api/identity/oidc/token.rs
+++ b/src/api/identity/oidc/token.rs
@@ -1,0 +1,2 @@
+pub mod requests;
+pub mod responses;

--- a/src/api/identity/oidc/token/requests.rs
+++ b/src/api/identity/oidc/token/requests.rs
@@ -1,0 +1,23 @@
+use crate::api::identity::oidc::token::responses::GeneratedSignedIdTokenResponse;
+use rustify_derive::Endpoint;
+
+/// ## Generate a signed ID (OIDC) token.
+///
+/// This endpoint generates a signed ID (OIDC) token.
+///
+/// * Path: identity/oidc/token/{name}
+/// * Method: GET
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/identity/tokens#generate-a-signed-id-token>
+#[derive(Builder, Debug, Default, Endpoint)]
+#[endpoint(
+    path = "identity/oidc/token/{self.name}",
+    method = "GET",
+    builder = "true",
+    response = "GeneratedSignedIdTokenResponse"
+)]
+#[builder(setter(into, strip_option), default)]
+pub struct GeneratedSignedIdTokenRequest {
+    /// Name of the role against which to generate a signed ID token.
+    #[endpoint(skip)]
+    pub name: String,
+}

--- a/src/api/identity/oidc/token/responses.rs
+++ b/src/api/identity/oidc/token/responses.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from executing
+/// [GeneratedSignedIdTokenRequest](crate::api::identity::oidc::requests::GeneratedSignedIdTokenRequest)
+#[derive(Deserialize, Debug, Serialize)]
+pub struct GeneratedSignedIdTokenResponse {
+    pub client_id: String,
+    pub token: String,
+    pub ttl: i64,
+}

--- a/src/api/pki/requests.rs
+++ b/src/api/pki/requests.rs
@@ -265,6 +265,7 @@ pub struct GenerateCertificateRequest {
     pub ttl: Option<String>,
     pub uri_sans: Option<String>,
     pub remove_roots_from_chain: Option<bool>,
+    pub user_ids: Option<Vec<String>>,
 }
 
 /// ## Revoke Certificate
@@ -523,7 +524,9 @@ pub struct SetRoleRequest {
     pub allow_localhost: Option<bool>,
     pub allow_subdomains: Option<bool>,
     pub allow_token_displayname: Option<bool>,
+    pub allow_wildcard_certificates: Option<bool>,
     pub allowed_domains: Option<Vec<String>>,
+    pub allowed_user_ids: Option<Vec<String>>,
     pub allowed_domains_template: Option<bool>,
     pub allowed_other_sans: Option<Vec<String>>,
     pub allowed_serial_numbers: Option<Vec<String>>,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -6,3 +6,4 @@ pub mod entity;
 pub mod entity_alias;
 pub mod group;
 pub mod group_alias;
+pub mod oidc;

--- a/src/identity/oidc.rs
+++ b/src/identity/oidc.rs
@@ -1,0 +1,6 @@
+use crate::client::Client;
+
+pub mod named_key;
+pub mod token;
+pub mod role;
+

--- a/src/identity/oidc/named_key.rs
+++ b/src/identity/oidc/named_key.rs
@@ -1,0 +1,35 @@
+use crate::api;
+use crate::api::identity::oidc::named_key::requests::{CreateNamedKeyRequest, CreateNamedKeyRequestBuilder};
+use crate::client::Client;
+use crate::error::ClientError;
+
+/// Create a named key.
+///
+/// See [CreateNamedKeyRequest]
+pub async fn set(
+    client: &impl Client,
+    name: &str,
+    opts: Option<&mut CreateNamedKeyRequestBuilder>
+) -> Result<(), ClientError> {
+    let mut t = CreateNamedKeyRequest::builder();
+    let endpoint = opts
+        .unwrap_or(&mut t)
+        .name(name)
+        .build()
+        .unwrap();
+
+    api::exec_with_empty(client, endpoint).await
+}
+
+/// Delete a named key.
+///
+/// See [DeleteNamedKeyRequest]
+pub async fn delete(
+    client: &impl Client,
+    name: &str,
+) -> Result<(), ClientError> {
+    let endpoint = CreateNamedKeyRequest::builder()
+        .name(name).build().unwrap();
+
+    api::exec_with_empty(client, endpoint).await
+}

--- a/src/identity/oidc/role.rs
+++ b/src/identity/oidc/role.rs
@@ -1,0 +1,51 @@
+use crate::api;
+use crate::api::identity::oidc::role::requests::{DeleteRoleRequest, ReadRoleRequest, SetRoleRequest, SetRoleRequestBuilder};
+use crate::api::identity::oidc::role::responses::ReadRoleResponse;
+use crate::client::Client;
+use crate::error::ClientError;
+
+/// Create or update a role.
+///
+/// See [SetRoleRequest]
+pub async fn set(
+    client: &impl Client,
+    name: &str,
+    key: &str,
+    opts: Option<&mut SetRoleRequestBuilder>
+) -> Result<(), ClientError> {
+    let mut t = SetRoleRequest::builder();
+    let endpoint = opts
+        .unwrap_or(&mut t)
+        .name(name)
+        .key(key)
+        .build()
+        .unwrap();
+
+    api::exec_with_empty(client, endpoint).await
+}
+
+/// Read a role.
+///
+/// See [ReadRoleRequest]
+pub  async fn read(
+    client: &impl Client,
+    name: &str,
+) -> Result<ReadRoleResponse, ClientError> {
+    let endpoint = ReadRoleRequest::builder()
+        .name(name).build().unwrap();
+
+    api::exec_with_result(client, endpoint).await
+}
+
+/// Delete a role.
+///
+/// See [DeleteRoleRequest]
+pub async fn delete(
+    client: &impl Client,
+    name: &str,
+) -> Result<(), ClientError> {
+    let endpoint = DeleteRoleRequest::builder()
+        .name(name).build().unwrap();
+
+    api::exec_with_empty(client, endpoint).await
+}

--- a/src/identity/oidc/token.rs
+++ b/src/identity/oidc/token.rs
@@ -1,0 +1,18 @@
+use crate::api;
+use crate::api::identity::oidc::token::requests::GeneratedSignedIdTokenRequest;
+use crate::api::identity::oidc::token::responses::GeneratedSignedIdTokenResponse;
+use crate::client::Client;
+use crate::error::ClientError;
+
+/// Generate a signed ID (OIDC) token.
+///
+/// See [GenerateSignedIdTokenRequest]
+pub async fn generate_signed_id_token(
+    client: &impl Client,
+    name: &str,
+) -> Result<GeneratedSignedIdTokenResponse, ClientError> {
+    let endpoint = GeneratedSignedIdTokenRequest::builder()
+        .name(name).build().unwrap();
+
+    api::exec_with_result(client, endpoint).await
+}


### PR DESCRIPTION
Bindings for multiple OIDC endpoints were missing.

I didn't have time to add necessary test code, but the code is used extensively in multiple applications. Obviously, feel free to reject because of this.