### PR TITLE
Add support for cubbyhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Support for `cubbyhole` secret engine.
 - Generate intermediate CSR using existing issuer (see `cert::ca::int::cross_sign`)
 - Generate intermediate CSR (see `issuer::int::generate`)
 - Read issuer's certificate (see `issuer::read`)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following features are currently supported:
   - [Userpass](https://developer.hashicorp.com/vault/docs/auth/userpass)
 - Secrets
   - [AWS](https://developer.hashicorp.com/vault/docs/secrets/aws)
+  - [Cubbyhole](https://developer.hashicorp.com/vault/docs/secrets/cubbyhole)
   - [Databases](https://developer.hashicorp.com/vault/api-docs/secret/databases)
   - [KV v1](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v1)
   - [KV v2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod aws;
+pub mod cubbyhole;
 pub mod database;
 pub mod identity;
 pub mod kv1;

--- a/src/api/cubbyhole.rs
+++ b/src/api/cubbyhole.rs
@@ -1,0 +1,2 @@
+pub mod requests;
+pub mod responses;

--- a/src/api/cubbyhole/requests.rs
+++ b/src/api/cubbyhole/requests.rs
@@ -1,0 +1,88 @@
+use super::responses::{GetSecretResponse, ListSecretResponse};
+
+use rustify_derive::Endpoint;
+use std::fmt::Debug;
+
+/// ## Read Secret
+/// This endpoint retrieves the secret at the specified location.
+///
+/// * Path: {self.mount}/{self.path}
+/// * Method: GET
+/// * Response: GetSecretResponse
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/cubbyhole#read-secret>
+#[derive(Builder, Debug, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/{self.path}",
+    response = "GetSecretResponse",
+    builder = "true"
+)]
+#[builder(setter(into))]
+pub struct GetSecretRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub path: String,
+}
+
+/// ## Set Secret
+/// This endpoint set or update a secret at the specified location.
+///
+/// * Path: {self.mount}/{self.path}
+/// * Method: POST
+/// * Response: N/A
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/cubbyhole#create-update-secret>
+#[derive(Builder, Debug, Endpoint)]
+#[endpoint(path = "{self.mount}/{self.path}", method = "POST", builder = "true")]
+#[builder(setter(into))]
+pub struct SetSecretRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub path: String,
+
+    // key/value pairs to pass Vault
+    // Must be as raw, otherwise payload would be sent as
+    // { data: { key: value, key2: value2 } } rather than plain { key: value, key2: value2 }
+    // Result in a secret with key "data" and erroneous valué
+    #[endpoint(raw)]
+    pub data: Vec<u8>,
+}
+
+/// ## List secret keys
+/// This endpoint list secrets at given location
+///
+/// * Path: {self.mount}/{self.path}
+/// * Method: LIST
+/// * Response: ListSecretResponse
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/cubbyhole#list-secrets>
+#[derive(Builder, Debug, Endpoint)]
+#[endpoint(
+    path = "{self.mount}/{self.path}",
+    method = "LIST",
+    builder = "true",
+    response = "ListSecretResponse"
+)]
+#[builder(setter(into))]
+pub struct ListSecretRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub path: String,
+}
+
+/// ## Delete secret
+/// This endpoint delete a secret at given location
+///
+/// * Path: {self.mount}/{self.path}
+/// * Method: DELETE
+/// * Response: N/A
+/// * Reference: <https://developer.hashicorp.com/vault/api-docs/secret/cubbyhole#delete-secret>
+#[derive(Builder, Debug, Endpoint)]
+#[endpoint(path = "{self.mount}/{self.path}", method = "DELETE", builder = "true")]
+#[builder(setter(into))]
+pub struct DeleteSecretRequest {
+    #[endpoint(skip)]
+    pub mount: String,
+    #[endpoint(skip)]
+    pub path: String,
+}

--- a/src/api/cubbyhole/requests.rs
+++ b/src/api/cubbyhole/requests.rs
@@ -43,7 +43,7 @@ pub struct SetSecretRequest {
     // key/value pairs to pass Vault
     // Must be as raw, otherwise payload would be sent as
     // { data: { key: value, key2: value2 } } rather than plain { key: value, key2: value2 }
-    // Result in a secret with key "data" and erroneous valué
+    // Result in a secret with key "data" and erroneous value
     #[endpoint(raw)]
     pub data: Vec<u8>,
 }

--- a/src/api/cubbyhole/responses.rs
+++ b/src/api/cubbyhole/responses.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Response from executing
+/// [GetSecretRequest][crate::api::cubbyhole::requests::GetSecretRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct GetSecretResponse {
+    pub data: Value,
+
+    /// Auth is always null, official doc does not document this field
+    pub auth: Option<String>,
+    pub lease_duration: i32,
+    pub lease_id: String,
+    pub renewable: bool,
+    pub request_id: String,
+}
+
+/// Response from executing
+/// [ListSecretRequest][crate::api::cubbyhole::requests::ListSecretRequest]
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ListSecretResponse {
+    pub data: ListSecretResponseKeys,
+
+    /// Auth is always null, official doc does not document this field
+    pub auth: Option<String>,
+    pub lease_duration: i32,
+    pub lease_id: String,
+    pub renewable: bool,
+}
+
+#[derive(Deserialize, Debug, Serialize)]
+pub struct ListSecretResponseKeys {
+    pub keys: Vec<String>,
+}

--- a/src/api/kv1/requests.rs
+++ b/src/api/kv1/requests.rs
@@ -43,7 +43,7 @@ pub struct SetSecretRequest {
     // key/value pairs to pass Vault
     // Must be as raw, otherwise payload would be sent as
     // { data: { key: value, key2: value2 } } rather than plain { key: value, key2: value2 }
-    // Result in a secret with key "data" and erroneous valué
+    // Result in a secret with key "data" and erroneous value
     #[endpoint(raw)]
     pub data: Vec<u8>,
 }

--- a/src/cubbyhole.rs
+++ b/src/cubbyhole.rs
@@ -50,13 +50,6 @@ pub async fn get<D: DeserializeOwned>(
     mount: &str,
     path: &str,
 ) -> Result<D, ClientError> {
-    // let endpoint = GetSecretRequest::builder()
-    //     .mount(mount)
-    //     .path(path)
-    //     .build()
-    //     .unwrap();
-
-    // let res = api::exec_with_no_result(client, endpoint).await?;
     let res = get_raw(client, mount, path).await?;
     serde_json::value::from_value(res.data).map_err(|e| ClientError::JsonParseError { source: e })
 }

--- a/src/cubbyhole.rs
+++ b/src/cubbyhole.rs
@@ -1,0 +1,108 @@
+use crate::{
+    api::{
+        self,
+        cubbyhole::{
+            requests::{
+                DeleteSecretRequest, GetSecretRequest, ListSecretRequest, SetSecretRequest,
+            },
+            responses::{GetSecretResponse, ListSecretResponse},
+        },
+    },
+    client::Client,
+    error::ClientError,
+};
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashMap;
+
+/// Sets the value of the secret at the given path
+///
+/// See [SetSecretRequest]
+pub async fn set<T: Serialize>(
+    client: &impl Client,
+    mount: &str,
+    path: &str,
+    data: &HashMap<&str, T>,
+) -> Result<(), ClientError> {
+    let data_value_json = data
+        .serialize(serde_json::value::Serializer)
+        .map_err(|e| ClientError::JsonParseError { source: e })?;
+
+    // Convert our JSON values as bytes to be sent to Vault
+    let data_u8 = serde_json::to_vec(&data_value_json)
+        .map_err(|e| ClientError::JsonParseError { source: e })?;
+
+    let endpoint = SetSecretRequest::builder()
+        .mount(mount)
+        .path(path)
+        .data(data_u8)
+        .build()
+        .unwrap();
+
+    api::exec_with_empty(client, endpoint).await
+}
+
+/// Get value of the secret at given path.
+/// Return the deserialized HashMap of secret directly,
+/// if you need to access additional fields such as lead_duration, use [get_raw]
+pub async fn get<D: DeserializeOwned>(
+    client: &impl Client,
+    mount: &str,
+    path: &str,
+) -> Result<D, ClientError> {
+    // let endpoint = GetSecretRequest::builder()
+    //     .mount(mount)
+    //     .path(path)
+    //     .build()
+    //     .unwrap();
+
+    // let res = api::exec_with_no_result(client, endpoint).await?;
+    let res = get_raw(client, mount, path).await?;
+    serde_json::value::from_value(res.data).map_err(|e| ClientError::JsonParseError { source: e })
+}
+
+/// Get value of the secret at given path, returning the raw response without deserialization
+/// Additional fields are available on raw response, such as lease_duration
+pub async fn get_raw(
+    client: &impl Client,
+    mount: &str,
+    path: &str,
+) -> Result<GetSecretResponse, ClientError> {
+    let endpoint = GetSecretRequest::builder()
+        .mount(mount)
+        .path(path)
+        .build()
+        .unwrap();
+
+    api::exec_with_no_result(client, endpoint).await
+}
+
+/// List secret keys at given location, returning raw server response
+///
+/// See [ListSecretRequest]
+pub async fn list(
+    client: &impl Client,
+    mount: &str,
+    path: &str,
+) -> Result<ListSecretResponse, ClientError> {
+    let endpoint = ListSecretRequest::builder()
+        .mount(mount)
+        .path(path)
+        .build()
+        .unwrap();
+
+    api::exec_with_no_result(client, endpoint).await
+}
+
+/// Delete secret at given location
+///
+/// See [DeleteSecretRequest]
+pub async fn delete(client: &impl Client, mount: &str, path: &str) -> Result<(), ClientError> {
+    let endpoint = DeleteSecretRequest::builder()
+        .mount(mount)
+        .path(path)
+        .build()
+        .unwrap();
+
+    api::exec_with_empty(client, endpoint).await
+}

--- a/src/kv1.rs
+++ b/src/kv1.rs
@@ -51,13 +51,6 @@ pub async fn get<D: DeserializeOwned>(
     mount: &str,
     path: &str,
 ) -> Result<D, ClientError> {
-    // let endpoint = GetSecretRequest::builder()
-    //     .mount(mount)
-    //     .path(path)
-    //     .build()
-    //     .unwrap();
-
-    // let res = api::exec_with_no_result(client, endpoint).await?;
     let res = get_raw(client, mount, path).await?;
     serde_json::value::from_value(res.data).map_err(|e| ClientError::JsonParseError { source: e })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,7 @@ pub mod api;
 pub mod auth;
 pub mod aws;
 pub mod client;
+pub mod cubbyhole;
 pub mod database;
 pub mod error;
 pub mod identity;

--- a/vaultrs-tests/tests/api_tests/cubbyhole.rs
+++ b/vaultrs-tests/tests/api_tests/cubbyhole.rs
@@ -23,14 +23,8 @@ async fn test_cubbyhole() {
 
     println!("{:?}", read_secret);
 
-    assert_eq!(
-        read_secret.get("key1").unwrap(),
-        expected_secret.get("key1").unwrap()
-    );
-    assert_eq!(
-        read_secret.get("key2").unwrap(),
-        expected_secret.get("key2").unwrap()
-    );
+    assert_eq!(read_secret["key1"], expected_secret["key1"]);
+    assert_eq!(read_secret["key2"], expected_secret["key2"]);
 
     // Read it as raw value
     let read_secret_raw: GetSecretResponse = cubbyhole::get_raw(client, mount, secret_path)
@@ -39,14 +33,8 @@ async fn test_cubbyhole() {
 
     println!("{:?}", read_secret_raw);
 
-    assert_eq!(
-        read_secret_raw.data.get("key1").unwrap(),
-        expected_secret.get("key1").unwrap()
-    );
-    assert_eq!(
-        read_secret_raw.data.get("key2").unwrap(),
-        expected_secret.get("key2").unwrap()
-    );
+    assert_eq!(read_secret_raw.data["key1"], expected_secret["key1"]);
+    assert_eq!(read_secret_raw.data["key2"], expected_secret["key2"]);
 
     // List secret keys
     let list_secret = cubbyhole::list(client, mount, "mysecret").await.unwrap();
@@ -81,7 +69,7 @@ async fn test_cubbyhole() {
     let read_secrets: HashMap<String, String> =
         cubbyhole::get(client, mount, "my/secrets").await.unwrap();
 
-    println!("{:}", read_secrets.get("key1").unwrap()); // value1
+    println!("{:}", read_secrets["key1"]); // value1
 
     let list_secret = cubbyhole::list(client, mount, "my").await.unwrap();
 

--- a/vaultrs-tests/tests/api_tests/cubbyhole.rs
+++ b/vaultrs-tests/tests/api_tests/cubbyhole.rs
@@ -1,0 +1,93 @@
+use crate::common::Test;
+use std::collections::HashMap;
+use vaultrs::{api::cubbyhole::responses::GetSecretResponse, cubbyhole, error::ClientError};
+
+#[tokio::test]
+async fn test_cubbyhole() {
+    let test = Test::builder().await;
+    let client = test.client();
+
+    // Use pre-mounted cubbyhole secret engine
+    let mount = "cubbyhole";
+    let secret_path = "mysecret/foo";
+
+    // Create test secrets
+    let expected_secret = HashMap::from([("key1", "value1"), ("key2", "value2")]);
+    cubbyhole::set(client, mount, secret_path, &expected_secret)
+        .await
+        .unwrap();
+
+    // Read it
+    let read_secret: HashMap<String, String> =
+        cubbyhole::get(client, mount, secret_path).await.unwrap();
+
+    println!("{:?}", read_secret);
+
+    assert_eq!(
+        read_secret.get("key1").unwrap(),
+        expected_secret.get("key1").unwrap()
+    );
+    assert_eq!(
+        read_secret.get("key2").unwrap(),
+        expected_secret.get("key2").unwrap()
+    );
+
+    // Read it as raw value
+    let read_secret_raw: GetSecretResponse = cubbyhole::get_raw(client, mount, secret_path)
+        .await
+        .unwrap();
+
+    println!("{:?}", read_secret_raw);
+
+    assert_eq!(
+        read_secret_raw.data.get("key1").unwrap(),
+        expected_secret.get("key1").unwrap()
+    );
+    assert_eq!(
+        read_secret_raw.data.get("key2").unwrap(),
+        expected_secret.get("key2").unwrap()
+    );
+
+    // List secret keys
+    let list_secret = cubbyhole::list(client, mount, "mysecret").await.unwrap();
+
+    println!("{:?}", list_secret);
+
+    assert_eq!(list_secret.data.keys, vec!["foo"]);
+
+    // Delete secret and read again and expect 404 to check deletion
+    cubbyhole::delete(client, mount, secret_path).await.unwrap();
+
+    let r = cubbyhole::get_raw(client, mount, secret_path).await;
+
+    match r.expect_err(&format!(
+        "Expected error when reading {} after delete.",
+        &secret_path
+    )) {
+        ClientError::APIError { code, .. } => {
+            assert_eq!(code, 404, "Expected error code 404 for non-existing secret")
+        }
+        e => {
+            panic!("Expected error to be APIError with code 404, got {:?}", e)
+        }
+    };
+
+    let my_secrets = HashMap::from([("key1", "value1"), ("key2", "value2")]);
+
+    cubbyhole::set(client, mount, "my/secrets", &my_secrets)
+        .await
+        .unwrap();
+
+    let read_secrets: HashMap<String, String> =
+        cubbyhole::get(client, mount, "my/secrets").await.unwrap();
+
+    println!("{:}", read_secrets.get("key1").unwrap()); // value1
+
+    let list_secret = cubbyhole::list(client, mount, "my").await.unwrap();
+
+    println!("{:?}", list_secret.data.keys); // [ "secrets" ]
+
+    cubbyhole::delete(client, mount, "my/secrets")
+        .await
+        .unwrap();
+}

--- a/vaultrs-tests/tests/api_tests/identity.rs
+++ b/vaultrs-tests/tests/api_tests/identity.rs
@@ -269,7 +269,7 @@ async fn test_merge_entity(client: &VaultClient) {
 async fn test_create_entity_alias(client: &VaultClient, entity_id: &str) -> String {
     let auth_response = sys::auth::list(client).await.unwrap();
 
-    let token_auth_response = auth_response.get("token/").unwrap();
+    let token_auth_response = &auth_response["token/"];
     let token_auth_accessor = &token_auth_response.accessor;
 
     let entity_alias = identity::entity_alias::create(
@@ -521,7 +521,7 @@ async fn test_group_alias(client: &VaultClient) -> String {
     .await
     .unwrap();
     let auth_response = sys::auth::list(client).await.unwrap();
-    let token_auth_response = auth_response.get("token/").unwrap();
+    let token_auth_response = &auth_response["token/"];
     let token_auth_accessor = &token_auth_response.accessor;
 
     let group = identity::group::read_by_name(client, GROUP_NAME)
@@ -543,7 +543,7 @@ async fn test_group_alias(client: &VaultClient) -> String {
 async fn test_update_group_alias_by_id(client: &VaultClient, group_alias_id: &str) {
     const NEW_NAME: &str = "new-name";
     let auth_response = sys::auth::list(client).await.unwrap();
-    let token_auth_response = auth_response.get("token/").unwrap();
+    let token_auth_response = &auth_response["token/"];
     let token_auth_accessor = &token_auth_response.accessor;
     identity::group_alias::update_by_id(
         client,

--- a/vaultrs-tests/tests/api_tests/kv1.rs
+++ b/vaultrs-tests/tests/api_tests/kv1.rs
@@ -23,14 +23,8 @@ async fn test_kv1() {
 
     println!("{:?}", read_secret);
 
-    assert_eq!(
-        read_secret.get("key1").unwrap(),
-        expected_secret.get("key1").unwrap()
-    );
-    assert_eq!(
-        read_secret.get("key2").unwrap(),
-        expected_secret.get("key2").unwrap()
-    );
+    assert_eq!(read_secret["key1"], expected_secret["key1"]);
+    assert_eq!(read_secret["key2"], expected_secret["key2"]);
 
     // Read it as raw value
     let read_secret_raw: GetSecretResponse =
@@ -38,14 +32,8 @@ async fn test_kv1() {
 
     println!("{:?}", read_secret_raw);
 
-    assert_eq!(
-        read_secret_raw.data.get("key1").unwrap(),
-        expected_secret.get("key1").unwrap()
-    );
-    assert_eq!(
-        read_secret_raw.data.get("key2").unwrap(),
-        expected_secret.get("key2").unwrap()
-    );
+    assert_eq!(read_secret_raw.data["key1"], expected_secret["key1"]);
+    assert_eq!(read_secret_raw.data["key2"], expected_secret["key2"]);
 
     // List secret keys
     let list_secret = kv1::list(client, mount, "mysecret").await.unwrap();
@@ -80,7 +68,7 @@ async fn test_kv1() {
     let read_secrets: HashMap<String, String> =
         kv1::get(client, mount, "my/secrets").await.unwrap();
 
-    println!("{:}", read_secrets.get("key1").unwrap()); // value1
+    println!("{:}", read_secrets["key1"]); // value1
 
     let list_secret = kv1::list(client, mount, "my").await.unwrap();
 

--- a/vaultrs-tests/tests/api_tests/main.rs
+++ b/vaultrs-tests/tests/api_tests/main.rs
@@ -3,6 +3,7 @@ mod aws;
 mod cert;
 mod client;
 mod common;
+mod cubbyhole;
 mod database;
 mod identity;
 mod kubernetes;


### PR DESCRIPTION
Add support for the cubbyhole secret engine. It is functionally equivalent to KV1, so the code is practically the same. I was considering a non-inlined re-export of the kv1 engine but could not get that working with new doc comments to reflect the fact it is for the cubbyhole - if there is a way to do this that may be better for maintainability.

Closes #6.