### PR TITLE
add `expiration` to `SignCertificateResponse`

### DIFF
--- a/src/api/pki/responses.rs
+++ b/src/api/pki/responses.rs
@@ -156,6 +156,7 @@ pub struct SignCertificateResponse {
     pub certificate: String,
     pub issuing_ca: String,
     pub serial_number: String,
+    pub expiration: u64,
 }
 
 /// Response from executing


### PR DESCRIPTION
Add `expiration` to `SignCertificateResponse` that wasn't parsed until then