### PR TITLE
fix: add optional `role` member to `LookupTokenResponse`

### DIFF
--- a/src/api/token/responses.rs
+++ b/src/api/token/responses.rs
@@ -29,6 +29,7 @@ pub struct LookupTokenResponse {
     pub path: String,
     pub policies: Vec<String>,
     pub renewable: bool,
+    pub role: Option<String>,
     pub ttl: u64,
 }
 


### PR DESCRIPTION
The [Lookup a token documentation](https://developer.hashicorp.com/vault/api-docs/auth/token#lookup-a-token-accessor) does not mention the `"role"` member, but it is returned for tokens that were created with a `role_name`. 

Tested with Vault `1.19.3`.