### PR TITLE
workaround for #137 in /sys/health

### DIFF
--- a/src/api/sys/requests.rs
+++ b/src/api/sys/requests.rs
@@ -249,51 +249,34 @@ pub struct WrappingLookupRequest {
 /// * Response: [ReadHealthResponse]
 /// * Reference: <https://developer.hashicorp.com/vault/api-docs/system/health#read-health-information>
 
-#[derive(Builder, Endpoint)]
+#[derive(Builder, Default, Endpoint)]
 #[endpoint(
-    path = "/sys/health?standbyok={self.standbyok}&perfstandbyok={self.perfstandbyok}&activecode={self.activecode}&standbycode={self.standbycode}&drsecondarycode={self.drsecondarycode}&haunhealthycode={self.haunhealthycode}&performancestandbycode={self.performancestandbycode}&removedcode={self.removedcode}&sealedcode={self.sealedcode}&uninitcode={self.uninitcode}",
+    path = "/sys/health",
     response = "ReadHealthResponse",
     builder = "true"
 )]
 #[builder(setter(into), default)]
 pub struct ReadHealthRequest {
-    #[endpoint(skip)]
-    pub standbyok: bool,
-    #[endpoint(skip)]
-    pub perfstandbyok: bool,
-    #[endpoint(skip)]
-    pub activecode: u16,
-    #[endpoint(skip)]
-    pub standbycode: u16,
-    #[endpoint(skip)]
-    pub drsecondarycode: u16,
-    #[endpoint(skip)]
-    pub haunhealthycode: u16,
-    #[endpoint(skip)]
-    pub performancestandbycode: u16,
-    #[endpoint(skip)]
-    pub removedcode: u16,
-    #[endpoint(skip)]
-    pub sealedcode: u16,
-    #[endpoint(skip)]
-    pub uninitcode: u16,
-}
-
-impl Default for ReadHealthRequest {
-    fn default() -> Self {
-        Self {
-            standbyok: false,
-            perfstandbyok: false,
-            activecode: 200,
-            standbycode: 429,
-            drsecondarycode: 472,
-            haunhealthycode: 474,
-            performancestandbycode: 473,
-            removedcode: 530,
-            sealedcode: 503,
-            uninitcode: 501,
-        }
-    }
+    #[endpoint(query)]
+    pub standbyok: Option<bool>,
+    #[endpoint(query)]
+    pub perfstandbyok: Option<bool>,
+    #[endpoint(query)]
+    pub activecode: Option<u16>,
+    #[endpoint(query)]
+    pub standbycode: Option<u16>,
+    #[endpoint(query)]
+    pub drsecondarycode: Option<u16>,
+    #[endpoint(query)]
+    pub haunhealthycode: Option<u16>,
+    #[endpoint(query)]
+    pub performancestandbycode: Option<u16>,
+    #[endpoint(query)]
+    pub removedcode: Option<u16>,
+    #[endpoint(query)]
+    pub sealedcode: Option<u16>,
+    #[endpoint(query)]
+    pub uninitcode: Option<u16>,
 }
 
 /// ## Start Initialization

--- a/src/api/sys/requests.rs
+++ b/src/api/sys/requests.rs
@@ -249,14 +249,52 @@ pub struct WrappingLookupRequest {
 /// * Response: [ReadHealthResponse]
 /// * Reference: <https://developer.hashicorp.com/vault/api-docs/system/health#read-health-information>
 
-#[derive(Builder, Default, Endpoint)]
+#[derive(Builder, Endpoint)]
 #[endpoint(
-    path = "/sys/health",
+    path = "/sys/health?standbyok={self.standbyok}&perfstandbyok={self.perfstandbyok}&activecode={self.activecode}&standbycode={self.standbycode}&drsecondarycode={self.drsecondarycode}&haunhealthycode={self.haunhealthycode}&performancestandbycode={self.performancestandbycode}&removedcode={self.removedcode}&sealedcode={self.sealedcode}&uninitcode={self.uninitcode}",
     response = "ReadHealthResponse",
     builder = "true"
 )]
 #[builder(setter(into), default)]
-pub struct ReadHealthRequest {}
+pub struct ReadHealthRequest {
+    #[endpoint(skip)]
+    pub standbyok: bool,
+    #[endpoint(skip)]
+    pub perfstandbyok: bool,
+    #[endpoint(skip)]
+    pub activecode: u16,
+    #[endpoint(skip)]
+    pub standbycode: u16,
+    #[endpoint(skip)]
+    pub drsecondarycode: u16,
+    #[endpoint(skip)]
+    pub haunhealthycode: u16,
+    #[endpoint(skip)]
+    pub performancestandbycode: u16,
+    #[endpoint(skip)]
+    pub removedcode: u16,
+    #[endpoint(skip)]
+    pub sealedcode: u16,
+    #[endpoint(skip)]
+    pub uninitcode: u16,
+}
+
+impl Default for ReadHealthRequest {
+    fn default() -> Self {
+        Self {
+            standbyok: false,
+            perfstandbyok: false,
+            activecode: 200,
+            standbycode: 429,
+            drsecondarycode: 472,
+            haunhealthycode: 474,
+            performancestandbycode: 473,
+            removedcode: 530,
+            sealedcode: 503,
+            uninitcode: 501,
+        }
+    }
+}
 
 /// ## Start Initialization
 ///

--- a/src/api/sys/responses.rs
+++ b/src/api/sys/responses.rs
@@ -121,7 +121,7 @@ pub struct ReadHealthResponse {
     pub enterprise: bool,
     pub echo_duration_ms: i64,
     pub clock_skew_ms: i64,
-    pub replication_primary_canary_age_ms: i64,
+    pub replication_primary_canary_age_ms: Option<i64>,
     pub removed_from_cluster: Option<bool>,
     pub ha_connection_healthy: Option<bool>,
     pub last_request_forwarding_heartbeat_ms: Option<i64>,

--- a/src/api/sys/responses.rs
+++ b/src/api/sys/responses.rs
@@ -107,16 +107,24 @@ pub struct WrappingLookupResponse {
 /// [ReadHealthRequest][crate::api::sys::requests::ReadHealthRequest]
 #[derive(Deserialize, Debug, Serialize)]
 pub struct ReadHealthResponse {
-    pub cluster_id: String,
-    pub cluster_name: String,
     pub initialized: bool,
-    pub performance_standby: bool,
-    pub replication_dr_mode: Option<String>,
-    pub replication_perf_mode: Option<String>,
     pub sealed: bool,
-    pub server_time_utc: u64,
     pub standby: bool,
+    pub performance_standby: bool,
+    pub replication_performance_mode: String,
+    pub replication_dr_mode: String,
+    pub server_time_utc: i64,
     pub version: String,
+    pub cluster_name: Option<String>,
+    pub cluster_id: Option<String>,
+    pub last_wal: Option<u64>,
+    pub enterprise: bool,
+    pub echo_duration_ms: i64,
+    pub clock_skew_ms: i64,
+    pub replication_primary_canary_age_ms: i64,
+    pub removed_from_cluster: Option<bool>,
+    pub ha_connection_healthy: Option<bool>,
+    pub last_request_forwarding_heartbeat_ms: Option<i64>,
 }
 
 /// Response from executing


### PR DESCRIPTION
The health endpoint returns non-200-status-codes WITH the `ReadHealthResponse` together, but `vaultrs` is just seeing the non-200 statuscode and throws an error. ignoring the actual content. As a workaround one can specify the return numbers that **vault** should send in certain situations.

Additionally the ReadHealthResponse no longer seemed to hold up with a `1.19` version of vault. So i updated it based on the go source code