### PR TITLE
Allow set a proxy in reqwest client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! mount::enable(&client, "aws_test", "aws", None).await?;
 //!
 //! // Configure AWS SE
-//! aws::config::set(&client, "aws_test", "access_key", "secret_key", Some(SetConfigurationRequest::builder()        
+//! aws::config::set(&client, "aws_test", "access_key", "secret_key", Some(SetConfigurationRequest::builder()
 //!     .max_retries(3)
 //!     .region("eu-central-1")
 //! )).await?;
@@ -246,6 +246,29 @@
 //! # }
 //! ```
 //!
+//! ### Proxy
+//!
+//! You can configure the client to use an HTTP or HTTPS proxy by setting the `proxy` option
+//! in `VaultClientSettingsBuilder`. This is useful for routing requests through a proxy server
+//! for logging, monitoring, or network policy reasons.
+//!
+//! ```no_run
+//! use vaultrs::client::{VaultClientSettingsBuilder, VaultClient};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let settings = VaultClientSettingsBuilder::default()
+//!     .address("https://127.0.0.1:8200")
+//!     .token("TOKEN")
+//!     .proxy("http://127.0.0.1:8080")
+//!     .build()
+//!     .unwrap();
+//!
+//! let client = VaultClient::new(settings).unwrap();
+//! // All requests made by `client` will be routed through the proxy
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! [Hashicorp Vault]: https://developer.hashicorp.com/vault
 //! [aws tests]: https://github.com/jmgilman/vaultrs/blob/master/vaultrs-tests/tests/api_tests/aws.rs

--- a/vaultrs-tests/tests/api_tests/client.rs
+++ b/vaultrs-tests/tests/api_tests/client.rs
@@ -45,6 +45,30 @@ fn build_without_address() {
     );
 }
 
+#[test]
+fn build_with_proxy() {
+    let expected_proxy = "https://example.com:1234";
+
+    let settings = VaultClientSettingsBuilder::default()
+        .address("http://127.0.0.1:8200")
+        .proxy(expected_proxy)
+        .build()
+        .unwrap();
+    assert_eq!(Url::parse(expected_proxy).unwrap(), settings.proxy.unwrap());
+    assert_eq!(
+        Url::parse("http://127.0.0.1:8200").unwrap(),
+        settings.address
+    );
+}
+
+#[test]
+#[should_panic]
+fn build_with_invalid_proxy_panics() {
+    let _ = VaultClientSettingsBuilder::default()
+        .proxy("invalid_url")
+        .build();
+}
+
 const VAULT_SKIP_VERIFY: &str = "VAULT_SKIP_VERIFY";
 
 fn build_client() -> VaultClient {


### PR DESCRIPTION
I´m looking to add the option to configure a proxy url when building the Vault client. 
This is something that I need in one of my projects and I also saw one issue #120 open.

I took the simple alternative of configuring the proxy directly into the HTTP client, but I saw that the rustify crate is being used, if needed I can see if I can spend time adding this config in that crate.

