### PR TITLE
Make token lookup issue time optional

### DIFF
--- a/src/api/token/responses.rs
+++ b/src/api/token/responses.rs
@@ -28,7 +28,7 @@ pub struct LookupTokenResponse {
     pub orphan: bool,
     pub path: String,
     pub policies: Vec<String>,
-    pub renewable: bool,
+    pub renewable: Option<bool>,
     pub role: Option<String>,
     pub ttl: u64,
 }


### PR DESCRIPTION
The `issue_time` and `renewable` fields have become optional in newer versions of vault.