### PR TITLE
enable native-tls to verify cerver CA

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -82,9 +82,12 @@ impl VaultClient {
     /// Creates a new [VaultClient] using the given [VaultClientSettings].
     #[instrument(skip(settings), err)]
     pub fn new(settings: VaultClientSettings) -> Result<VaultClient, ClientError> {
-        #[cfg(not(feature = "rustls"))]
+        #[cfg(not(any(feature = "rustls", feature = "native-tls")))]
         let mut http_client = reqwest::ClientBuilder::new();
 
+        #[cfg(feature = "native-tls")]
+        let mut http_client = reqwest::ClientBuilder::new().use_native_tls();
+        
         #[cfg(feature = "rustls")]
         let mut http_client = reqwest::ClientBuilder::new().use_rustls_tls();
 


### PR DESCRIPTION
it appears the feature for native-tls already present in the cargo.toml but the code does not allow enabling this feature. I understand that using Mutual TLS is still not possible but at least this way it is possible to use OS cert store to use reqwest's native-tls