### PR TITLE
Enable using the userpass client to log in to an ldap backend

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -334,13 +334,13 @@ where
 
 pub async fn auth<E>(client: &impl Client, endpoint: E) -> Result<AuthInfo, ClientError>
 where
-    E: Endpoint<Response = ()>,
+    E: Endpoint,
 {
     trace!(
         "Executing {} and returning authentication info",
         endpoint.path()
     );
-    let r: EndpointResult<()> = endpoint
+    let r: EndpointResult<_> = endpoint
         .with_middleware(client.middle())
         .exec(client.http())
         .await

--- a/src/api/auth/userpass/requests.rs
+++ b/src/api/auth/userpass/requests.rs
@@ -1,4 +1,4 @@
-use super::responses::{ListUsersResponse, ReadUserResponse};
+use super::responses::{ListUsersResponse, LoginResponse, ReadUserResponse};
 use rustify_derive::Endpoint;
 
 /// ## Create/Update User
@@ -149,6 +149,7 @@ pub struct ListUsersRequest {
 #[endpoint(
     path = "/auth/{self.mount}/login/{self.username}",
     method = "POST",
+    response = "LoginResponse",
     builder = "true"
 )]
 #[builder(setter(into, strip_option), default)]

--- a/src/api/auth/userpass/responses.rs
+++ b/src/api/auth/userpass/responses.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Response from executing
 /// [ReadUserRequest][crate::api::auth::userpass::requests::ReadUserRequest]
@@ -21,3 +22,5 @@ pub struct ReadUserResponse {
 pub struct ListUsersResponse {
     pub keys: Vec<String>,
 }
+
+pub type LoginResponse = HashMap<(), ()>;


### PR DESCRIPTION
The ldap backend login response has `"data": {}` because of this line:
https://github.com/hashicorp/vault/blob/main/builtin/credential/ldap/backend.go#L121

(This is different from the other backends I looked at, they all use a pattern more like [this](https://github.com/hashicorp/vault/blob/main/builtin/credential/userpass/path_login.go#L56), so `logical.Response.Data` would always be nil.)

When deserializing the login response the type of `EndpointResult.data` is currently `Option<()>`, but testing with serde shows that `"data": null` is the only value that can be read into that type. Changing the userpass login response type to `HashMap<(), ()>` allows data to be `null` or `{}`, so we can use it to login against an ldap backend.

Fixes #104 