### PR TITLE
Add associated_data support for transit data_key API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,6 +3314,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls-pki-types",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.13", default-features = false }
 rustify_derive = { version = "0.5.5", default-features = false }
 rustify = { version = "0.7", default-features = false }
 rustls-pki-types = { version = "1", default-features = false }
+semver = "1.0.27"
 serde_json = { version = "1.0.94", default-features = false }
 serde = { version = "1.0.158", features = ["derive"], default-features = false }
 sha2 = { version = "0.10.6", default-features = false }

--- a/vaultrs-tests/Cargo.toml
+++ b/vaultrs-tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "vaultrs-tests"
 version = "0.0.0"
 description = "Integration tests for vaultrs and vaultrs login"
 publish = false
-authors.workspace = true 
+authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -20,6 +20,7 @@ data-encoding.workspace = true
 rcgen = { workspace = true, features = ["pem", "aws_lc_rs"] }
 reqwest = { workspace =  true, default-features = false, features = ["form"] }
 rustls-pki-types.workspace = true
+semver.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/vaultrs-tests/tests/api_tests/common.rs
+++ b/vaultrs-tests/tests/api_tests/common.rs
@@ -1,4 +1,4 @@
 mod images;
 mod setup;
-pub use images::{KUB_ACCOUNT_NAME, KUB_NAMESPACE};
+pub use images::{TestedVersion, KUB_ACCOUNT_NAME, KUB_NAMESPACE};
 pub use setup::{TestBuilder, POSTGRES_PASSWORD, POSTGRES_USER};

--- a/vaultrs-tests/tests/api_tests/common/images.rs
+++ b/vaultrs-tests/tests/api_tests/common/images.rs
@@ -330,9 +330,25 @@ impl Image for Oidc {
     }
 }
 
-pub(crate) const TESTED_VERSION: [(&str, &str); 2] = [
-    ("hashicorp/vault", "1.16.3"),
-    ("ghcr.io/openbao/openbao", "2.4.4"),
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TestedVersion {
+    pub image_name: &'static str,
+    pub image_tag: &'static str,
+}
+
+pub(crate) const TESTED_VERSIONS: [TestedVersion; 3] = [
+    TestedVersion {
+        image_name: VAULT_NAME,
+        image_tag: VAULT_TAG,
+    },
+    TestedVersion {
+        image_name: "ghcr.io/openbao/openbao",
+        image_tag: "2.4.4",
+    },
+    TestedVersion {
+        image_name: "ghcr.io/openbao/openbao",
+        image_tag: "2.5.1",
+    },
 ];
 
 pub const KUB_ACCOUNT_NAME: &str = "vault-auth";

--- a/vaultrs-tests/tests/api_tests/common/setup.rs
+++ b/vaultrs-tests/tests/api_tests/common/setup.rs
@@ -1,4 +1,4 @@
-use crate::common::images::TESTED_VERSION;
+use crate::common::images::{TestedVersion, TESTED_VERSIONS};
 
 use super::images::{Nginx, Oidc, ProdVault, TlsVault, Vault};
 use rcgen::{CertificateParams, Issuer, KeyPair};
@@ -23,7 +23,7 @@ pub struct TestBuilder<I> {
     ca_cert: Option<PathBuf>,
     image: I,
     client: VaultClientSettingsBuilder,
-    ignore_openbao: Option<String>,
+    ignored_versions_reasons: Option<HashMap<TestedVersion, &'static str>>,
 }
 
 impl<I> TestBuilder<I>
@@ -42,14 +42,23 @@ where
         I: Clone,
     {
         let mut tests = JoinSet::new();
-        let mut names = HashMap::with_capacity(TESTED_VERSION.len());
+        let mut names = HashMap::with_capacity(TESTED_VERSIONS.len());
 
-        for (image, tag) in TESTED_VERSION.into_iter().filter(|(image, tag)| {
-            if let Some(reason) = self.ignore_openbao.as_ref() {
-                if image.contains("openbao") {
-                    eprintln!("ignore {image}:{tag} because {reason}");
-                    return false;
-                }
+        for TestedVersion {
+            image_name: image,
+            image_tag: tag,
+        } in TESTED_VERSIONS.into_iter().filter(|tested_version| {
+            if let Some(reason) = self
+                .ignored_versions_reasons
+                .as_ref()
+                .and_then(|reasons| reasons.get(tested_version))
+            {
+                let TestedVersion {
+                    image_name,
+                    image_tag,
+                } = tested_version;
+                eprintln!("ignore {image_name}:{image_tag} because {reason}");
+                return false;
             }
             true
         }) {
@@ -78,8 +87,33 @@ where
         }
     }
 
-    pub(crate) fn ignore_openbao(mut self, reason: &str) -> TestBuilder<I> {
-        self.ignore_openbao = Some(reason.to_owned());
+    pub(crate) fn ignore_openbao(self, reason: &'static str) -> TestBuilder<I> {
+        self.ignore_version_predicate(
+            |TestedVersion {
+                 image_name,
+                 image_tag: _,
+             }| {
+                if image_name.contains("openbao") {
+                    Some(reason)
+                } else {
+                    None
+                }
+            },
+        )
+    }
+
+    pub(crate) fn ignore_version_predicate<P>(mut self, mut predicate: P) -> TestBuilder<I>
+    where
+        P: FnMut(TestedVersion) -> Option<&'static str>,
+    {
+        self.ignored_versions_reasons = Some(
+            TESTED_VERSIONS
+                .iter()
+                .filter_map(|tested_version| {
+                    predicate(*tested_version).map(|reason| (*tested_version, reason))
+                })
+                .collect(),
+        );
         self
     }
 
@@ -187,7 +221,7 @@ impl TestBuilder<Vault> {
             ca_cert: None,
             image: Vault::default(),
             client,
-            ignore_openbao: None,
+            ignored_versions_reasons: None,
         }
     }
 
@@ -234,7 +268,7 @@ impl TestBuilder<ProdVault> {
             ca_cert: None,
             image: ProdVault::default(),
             client: VaultClientSettingsBuilder::default(),
-            ignore_openbao: None,
+            ignored_versions_reasons: None,
         }
     }
 }
@@ -268,7 +302,7 @@ impl TestBuilder<TlsVault> {
             ca_cert: Some(ca_cert),
             image,
             client,
-            ignore_openbao: None,
+            ignored_versions_reasons: None,
         }
     }
 }
@@ -286,7 +320,7 @@ where
             ca_cert: self.ca_cert.clone(),
             image: self.image.clone(),
             client: self.client.clone(),
-            ignore_openbao: self.ignore_openbao.clone(),
+            ignored_versions_reasons: self.ignored_versions_reasons.clone(),
         }
     }
 }

--- a/vaultrs-tests/tests/api_tests/transit.rs
+++ b/vaultrs-tests/tests/api_tests/transit.rs
@@ -1,10 +1,11 @@
 use base64::{engine::general_purpose, Engine as _};
 use data_encoding::HEXLOWER;
+use semver::{Version, VersionReq};
 use sha2::{Digest, Sha256};
 use tracing::debug;
 use vaultrs::{client::VaultClient, error::ClientError, sys::mount};
 
-use crate::common::TestBuilder;
+use crate::common::{TestBuilder, TestedVersion};
 
 #[tokio::test]
 async fn test() {
@@ -37,6 +38,32 @@ async fn test() {
             cache::test_configure_and_read(&endpoint).await;
 
             wrapping_key::test_read(&endpoint).await;
+        })
+        .await;
+
+    TestBuilder::new()
+        .ignore_version_predicate(
+            |TestedVersion {
+                 image_name,
+                 image_tag,
+             }| {
+                if image_name.contains("openbao")
+                    && VersionReq::parse(">=2.5.0")
+                        .unwrap()
+                        .matches(&Version::parse(image_tag).unwrap())
+                {
+                    None
+                } else {
+                    Some("associated data on data key is only supported on openbao>=2.5.0")
+                }
+            },
+        )
+        .check(|test| async move {
+            let client = test.client();
+            let endpoint = TransitEndpoint::setup(client).await.unwrap();
+
+            key::test_create(&endpoint).await;
+            generate::test_data_key_decrypt_with_associated_data(&endpoint).await;
         })
         .await;
 }
@@ -787,12 +814,13 @@ mod data {
 
 mod generate {
     use super::TransitEndpoint;
+    use base64::{engine::general_purpose, Engine as _};
     use vaultrs::api::transit::requests::{
-        DataKeyType, GenerateDataKeyRequest, GenerateRandomBytesRequest, HashDataRequest,
-        RandomBytesSource,
+        DataKeyType, DecryptDataRequest, GenerateDataKeyRequest, GenerateRandomBytesRequest,
+        HashDataRequest, RandomBytesSource,
     };
     use vaultrs::api::transit::{HashAlgorithm, OutputFormat};
-    use vaultrs::transit::generate;
+    use vaultrs::transit::{data, generate};
 
     pub async fn test_data_key(endpoint: &TransitEndpoint<'_>) {
         let resp = generate::data_key(
@@ -805,6 +833,47 @@ mod generate {
         .await
         .unwrap();
         assert!(&resp.plaintext.is_some())
+    }
+
+    pub async fn test_data_key_decrypt_with_associated_data(endpoint: &TransitEndpoint<'_>) {
+        let associated_data = &general_purpose::STANDARD.encode("associated data");
+        let bad_associated_data = &general_purpose::STANDARD.encode("bad associated data");
+
+        let resp = generate::data_key(
+            endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.basic,
+            DataKeyType::Plaintext,
+            Some(
+                GenerateDataKeyRequest::builder()
+                    .bits(512u16)
+                    .associated_data(associated_data),
+            ),
+        )
+        .await
+        .unwrap();
+        assert!(&resp.plaintext.is_some());
+
+        let decrypted = data::decrypt(
+            endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.basic,
+            &resp.ciphertext,
+            Some(DecryptDataRequest::builder().associated_data(associated_data)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(decrypted.plaintext, resp.plaintext.unwrap());
+
+        data::decrypt(
+            endpoint.client,
+            &endpoint.path,
+            &endpoint.keys.basic,
+            &resp.ciphertext,
+            Some(DecryptDataRequest::builder().associated_data(bad_associated_data)),
+        )
+        .await
+        .unwrap_err();
     }
 
     pub async fn test_random_bytes(endpoint: &TransitEndpoint<'_>) {

--- a/vaultrs/src/api/transit/requests.rs
+++ b/vaultrs/src/api/transit/requests.rs
@@ -551,6 +551,10 @@ pub struct GenerateDataKeyRequest {
     /// Specifies the key derivation context, provided as a base64-encoded
     /// string. This must be provided if derivation is enabled.
     pub context: Option<String>,
+    /// Specifies base64 encoded associated data (also known as additional data or AAD)
+    /// to also be authenticated with AEAD ciphers (aes128-gcm96, aes256-gcm,
+    /// chacha20-poly1305, and xchacha20-poly1305).
+    pub associated_data: Option<String>,
     /// Specifies a nonce value, provided as base64 encoded. Must be provided if
     /// convergent encryption is enabled for this key and the key was generated
     /// with Vault 0.6.1. Not required for keys created in 0.6.2+. The value


### PR DESCRIPTION
See https://openbao.org/api-docs/secret/transit/#parameters-16 and https://github.com/openbao/openbao/pull/1828

Most of the changes are in the tests to allow ignoring a test for some versions of vault/openbao.

It is now testing both openbao 2.4.4 and 2.5.1, not sure if it is ok for github actions
